### PR TITLE
Individual shareables respected when changing worlds indirectly

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
@@ -93,7 +93,7 @@ final class ShareHandler {
             PlayerProfile profile = fromWorldGroup.getPlayerData(event.getPlayer());
             if (!fromWorldGroup.containsWorld(event.getToWorld().getName())) {
                 this.addFromProfile(fromWorldGroup,
-                        Sharables.allOf(), profile);
+                        Sharables.fromShares(fromWorldGroup.getShares()), profile);
             } else {
                 if (!fromWorldGroup.getShares().isSharing(Sharables.all()) || !fromWorldGroup.getNegativeShares().isEmpty()) {
                     this.addFromProfile(fromWorldGroup, Sharables.fromShares(fromWorldGroup.getShares()), profile);
@@ -115,7 +115,7 @@ final class ShareHandler {
                 } else {
                     PlayerProfile profile = toWorldGroup.getPlayerData(event.getPlayer());
                     if (!toWorldGroup.containsWorld(event.getFromWorld().getName())) {
-                        Shares sharesToAdd = Sharables.allOf();
+                        Shares sharesToAdd = Sharables.fromShares(toWorldGroup.getShares());
                         this.addToProfile(toWorldGroup,
                                 sharesToAdd, profile);
                         sharesToUpdate.addAll(sharesToAdd);


### PR DESCRIPTION
The default case, if the from and/or to worlds were not in the same group, was to not respect individual shareables and dump all data into the profile.  Since data are serialized via a hash map, this caused a race condition/conflict where the profiles would store/apply their shares in an unpredictable way.  That is, even though one group may want to declare a shareable, if any of the groups do not contain the from/to world, their shares could be overridden by the "Shareables.allOf()".  

Basically, this causes the situation reported by Uncovery in the forum (I'm from his server).  This commit just makes it so that the persistent profile always respects individual shares, so that the order in which profiles are applied is not important.

I've tested it, it compiles and passes the built-in tests, and it fixes the bug.
