### PR TITLE
Permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -105,3 +105,7 @@ commands:
   mvinvd:
     description: Generic Multiverse-Inventories Command
     usage: /<command>
+
+permissions:
+  multiverse.inventories.info
+    description: Gemeric Multiverse-Inventories Permission


### PR DESCRIPTION
I made a plugin that reloads plugins, and when your plugin is reloaded it says there is a problem with a permission being registered already. It is not recommended by most most developers that you register permissions through the Java source but instead through the plugin.yml. It would be beneficial that you change that if you could. If i haven't added all of the permissions please add the rest.
