### PR TITLE
Load files using UTF-8 encoding

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/util/EncodedConfiguration.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/util/EncodedConfiguration.java
@@ -39,6 +39,23 @@ public class EncodedConfiguration extends EnhancedConfiguration {
     }
 
     @Override
+    public void load(InputStream stream) throws IOException, InvalidConfigurationException {
+        Validate.notNull(stream, "Stream cannot be null");
+        InputStreamReader reader = new InputStreamReader(stream, charset);
+        StringBuilder builder = new StringBuilder();
+        BufferedReader input = new BufferedReader(reader);
+        try {
+            String line;
+            while ((line = input.readLine()) != null) {
+                builder.append(line).append('\n');
+            }
+        } finally {
+            input.close();
+        }
+        loadFromString(builder.toString());
+    }
+
+    @Override
     public void save(File file) throws IOException {
         Validate.notNull(file, "File cannot be null");
 


### PR DESCRIPTION
The default load method calls new InputStreamReader(steam), which is documented "Create an InputStreamReader that uses the default charset".
Loading configurations will thus throw an exception on non UTF-8 systems by default if there is UTF-8 encoding, even though saving is successful.
