### PR TITLE
Store WorldGroupProfiles all-lowercase. Fixes Multiverse/Multiverse-Inventories#175

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/YamlGroupManager.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/YamlGroupManager.java
@@ -63,7 +63,7 @@ final class YamlGroupManager extends AbstractGroupManager {
         }
 
         for (final WorldGroupProfile worldGroup : worldGroups) {
-            getGroupNames().put(worldGroup.getName(), worldGroup);
+            getGroupNames().put(worldGroup.getName().toLowerCase(), worldGroup);
         }
     }
 


### PR DESCRIPTION
**The Issue:**

At the moment, when a new group is created with uppercase letters, the group works fine and all commands work, until you reload or restart the server.  
After the reload, the groups will all still be listed in /mvinv list, but cannot be edited, deleted or otherwise modified with any other command. The groups still seem to work, though.

**PR Breakdown:**

At the moment, WorldGroupProfiles are
- stored with getName().toLowerCase() when the group is first created
- looked up by the group's lowercase name
- but stored with getName() without converting the name to lowercase when the YAML file is loaded.

This essentially leads to getGroupManager().getGroup() returning _null_ instead of the actual group, even when the name is correctly spelled.

This PR changes that and makes YamlGroupManager store the groups in the map with their lowercase name as key.

**Testing Results and Materials:**
- Compiled .jar [here](http://www.mediafire.com/download/1tvva1vek76wjx7/Multiverse-Inventories-2.5.jar), already tested and works.
- The constructor in YAMLGroupManager.java was the only method where the WorldGroupProfile was not .put in the map by its lowercase name.
