### PR TITLE
Force bed spawn to be set when changing worlds

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/api/share/Sharables.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/api/share/Sharables.java
@@ -495,7 +495,7 @@ public final class Sharables implements Shares {
                         player.setBedSpawnLocation(player.getWorld().getSpawnLocation());
                         return false;
                     }
-                    player.setBedSpawnLocation(loc);
+                    player.setBedSpawnLocation(loc, true);
                     return true;
                 }
             }).serializer(new ProfileEntry(false, DataStrings.PLAYER_BED_SPAWN_LOCATION), new LocationSerializer())


### PR DESCRIPTION
Fixes #162 and #186.

`getBedSpawnLocation()` returns a spawnable location around a bed, instead of the bed itself. Reusing this same location in `setBedSpawnLocation()` would cause the game to attempt to set the bed to a location that doesn't actually have a bed, and cause the home bed location to be set to null.

This way, with the `override = true` flag, the coordinates get set regardless of if a valid bed exists at that location (which should probably be the case anyway, since MV should set the values to whatever they were previously even if they were invalid).

Also, note that I have almost 0 experience with Bukkit API, so please do tell me if this causes any adverse side effects (I tested it and it seems to work just fine).
