### PR TITLE
Update to compile correctly with spigot 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,10 +248,6 @@ and adjust the build number accordingly -->
             <exclusions>
                 <exclusion>
                     <groupId>org.bukkit</groupId>
-                    <artifactId>craftbukkit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
                     <artifactId>bukkit</artifactId>
                 </exclusion>
             </exclusions>
@@ -284,10 +280,6 @@ and adjust the build number accordingly -->
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.spigotmc</groupId>
-                    <artifactId>spigot-api</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <!-- End of Multiverse Adventure Dependency -->
@@ -302,10 +294,6 @@ and adjust the build number accordingly -->
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,10 @@ and adjust the build number accordingly -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.6.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <!-- Jar Plugin -->
@@ -204,6 +204,13 @@ and adjust the build number accordingly -->
         </plugins>
     </build>
     <dependencies>
+        <!-- Start of spigotmc Dependency -->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.12-R0.1-SNAPSHOT</version>
+        </dependency>
+        <!-- End of spigotmc Dependency -->
         <!-- Start of Multiverse Core Dependency -->
         <dependency>
             <groupId>com.onarandombox.multiversecore</groupId>
@@ -220,6 +227,14 @@ and adjust the build number accordingly -->
                     <groupId>com.dumptruckman.minecraft</groupId>
                     <artifactId>buscript</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- End of Multiverse Core Dependency -->
@@ -234,6 +249,10 @@ and adjust the build number accordingly -->
                 <exclusion>
                     <groupId>org.bukkit</groupId>
                     <artifactId>craftbukkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -265,6 +284,10 @@ and adjust the build number accordingly -->
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- End of Multiverse Adventure Dependency -->
@@ -279,6 +302,10 @@ and adjust the build number accordingly -->
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/com/onarandombox/multiverseinventories/DefaultMessageProvider.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/DefaultMessageProvider.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -126,8 +127,8 @@ class DefaultMessageProvider implements LazyLocaleMessageProvider {
 
         messages.put(l, new HashMap<Message, List<String>>(Message.values().length));
 
-        FileConfiguration resconfig = (resstream == null) ? null : YamlConfiguration.loadConfiguration(resstream);
-        FileConfiguration fileconfig = (filestream == null) ? null : YamlConfiguration.loadConfiguration(filestream);
+        FileConfiguration resconfig = (resstream == null) ? null : YamlConfiguration.loadConfiguration(new InputStreamReader(resstream));
+        FileConfiguration fileconfig = (filestream == null) ? null : YamlConfiguration.loadConfiguration(new InputStreamReader(filestream));
         for (Message m : Message.values()) {
             List<String> values = m.getDefault();
 

--- a/src/test/java/com/onarandombox/multiverseinventories/util/MockPlayer.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/MockPlayer.java
@@ -2,9 +2,12 @@ package com.onarandombox.multiverseinventories.util;
 
 import com.onarandombox.multiverseinventories.api.PlayerStats;
 import org.bukkit.*;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
+import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationAbandonedEvent;
 import org.bukkit.entity.*;
@@ -201,16 +204,6 @@ public class MockPlayer implements Player {
     }
 
     @Override
-    public int _INVALID_getLastDamage() {
-        return 0;
-    }
-
-    @Override
-    public void _INVALID_setLastDamage(int i) {
-
-    }
-
-    @Override
     public void setCustomName(String s) {
 
     }
@@ -243,36 +236,6 @@ public class MockPlayer implements Player {
     @Override
     public boolean setLeashHolder(Entity entity) {
         return false;
-    }
-
-    @Override
-    public void _INVALID_damage(int i) {
-
-    }
-
-    @Override
-    public void _INVALID_damage(int i, Entity entity) {
-
-    }
-
-    @Override
-    public int _INVALID_getHealth() {
-        return 0;
-    }
-
-    @Override
-    public void _INVALID_setHealth(int i) {
-
-    }
-
-    @Override
-    public int _INVALID_getMaxHealth() {
-        return 0;
-    }
-
-    @Override
-    public void _INVALID_setMaxHealth(int i) {
-
     }
 
     @Override
@@ -901,7 +864,6 @@ public class MockPlayer implements Player {
         //To change body of implemented methods use File | Settings | File Templates.
     }
 
-
     @Override
     public double getEyeHeight() {
         return 0;  //To change body of implemented methods use File | Settings | File Templates.
@@ -914,11 +876,6 @@ public class MockPlayer implements Player {
 
     @Override
     public Location getEyeLocation() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    @Override
-    public List<Block> getLineOfSight(HashSet<Byte> bytes, int i) {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
@@ -1116,11 +1073,6 @@ public class MockPlayer implements Player {
     @Override
     public boolean isBanned() {
         return false;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    @Override
-    public void setBanned(boolean b) {
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 
     @Override
@@ -1572,5 +1524,42 @@ public class MockPlayer implements Player {
     @Override
     public boolean removeScoreboardTag(String s) {
         return false;
+    }
+
+    @Override
+    public AdvancementProgress getAdvancementProgress(Advancement a)
+    {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public String getLocale()
+    {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public Entity getShoulderEntityLeft(){
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public void setShoulderEntityLeft(Entity entity){
+        
+    }
+
+    @Override
+    public Entity getShoulderEntityRight(){
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public void setShoulderEntityRight(Entity entity){
+	
+    }
+
+    @Override
+    public PistonMoveReaction getPistonMoveReaction(){
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 }


### PR DESCRIPTION
Changes to support new API in bukkit/spigot 1.12:
1) For MockPlayer.jar test class: Implemented new overrides and removed old ones that no longer exist.
2) For DefaultMessageProvider.java: [YamlConfiguration.loadConfiguration(InputStream stream);](url) removed from API in 1.12, replaced with [YamlConfiguration.loadConfiguration(Reader reader);](url)
3) For pom.xml: Source and target updated to Java 8 because Minecraft 1.12 server code is now compiled with Java 8. Added dependency for bukkit/spigot 1.12 so that it compiles with the changes in item 1 and 2 above.