### PR TITLE
Fix Player Name Changes

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/DataStrings.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/DataStrings.java
@@ -66,10 +66,6 @@ public class DataStrings {
      */
     public static final String PLAYER_SHOULD_LOAD = "shouldLoad";
     /**
-     * Player last known name identifier.
-     */
-    public static final String PLAYER_LAST_KNOWN_NAME = "lastKnownName";
-    /**
      * Player bed spawn location identifier.
      */
     public static final String PLAYER_PROFILE_TYPE = "profileType";

--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -15,11 +15,12 @@ import com.onarandombox.multiverseinventories.profile.GlobalProfile;
 import com.onarandombox.multiverseinventories.profile.PlayerProfile;
 import com.onarandombox.multiverseinventories.profile.ProfileType;
 import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.json.simple.parser.JSONParser;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +40,7 @@ class FlatFileProfileDataSource implements ProfileDataSource {
 
     private static final String JSON = ".json";
 
-    private final JSONParser JSON_PARSER = new JSONParser();
+    private final JSONParser JSON_PARSER = new JSONParser(JSONParser.MODE_JSON_SIMPLE);
 
     private final ExecutorService fileIOExecutorService = Executors.newSingleThreadExecutor();
 
@@ -338,10 +339,10 @@ class FlatFileProfileDataSource implements ProfileDataSource {
         if (stats.isEmpty()) {
             return;
         }
-        org.json.simple.JSONObject jsonStats = null;
+        JSONObject jsonStats = null;
         try {
-            jsonStats = (org.json.simple.JSONObject) JSON_PARSER.parse(stats);
-        } catch (org.json.simple.parser.ParseException e) {
+            jsonStats = (JSONObject) JSON_PARSER.parse(stats);
+        } catch (ParseException e) {
             Logging.warning("Could not parse stats for player'" + profile.getPlayer().getName() + "' for " +
                     profile.getContainerType() + " '" + profile.getContainerName() + "': " + e.getMessage());
         } catch (ClassCastException e) {

--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -489,8 +489,6 @@ class FlatFileProfileDataSource implements ProfileDataSource {
                 globalProfile.setLastWorld(playerData.get(key).toString());
             } else if (key.equalsIgnoreCase(DataStrings.PLAYER_SHOULD_LOAD)) {
                 globalProfile.setLoadOnLogin(Boolean.valueOf(playerData.get(key).toString()));
-            } else if (key.equalsIgnoreCase(DataStrings.PLAYER_LAST_KNOWN_NAME)) {
-                globalProfile.setLastKnownName(playerData.get(key).toString());
             }
         }
         return globalProfile;
@@ -526,7 +524,6 @@ class FlatFileProfileDataSource implements ProfileDataSource {
             result.put(DataStrings.PLAYER_LAST_WORLD, profile.getLastWorld());
         }
         result.put(DataStrings.PLAYER_SHOULD_LOAD, profile.shouldLoadOnLogin());
-        result.put(DataStrings.PLAYER_LAST_KNOWN_NAME, profile.getLastKnownName());
         return result;
     }
 

--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -16,6 +16,7 @@ import com.onarandombox.multiverseinventories.profile.PlayerProfile;
 import com.onarandombox.multiverseinventories.profile.ProfileType;
 import net.minidev.json.JSONObject;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.json.simple.parser.JSONParser;
@@ -111,16 +112,10 @@ class FlatFileProfileDataSource implements ProfileDataSource {
 
     private File getFolder(ContainerType type, String folderName) {
         File folder;
-        switch (type) {
-            case GROUP:
-                folder = new File(this.groupFolder, folderName);
-                break;
-            case WORLD:
-                folder = new File(this.worldFolder, folderName);
-                break;
-            default:
-                folder = new File(this.worldFolder, folderName);
-                break;
+        if (type == ContainerType.GROUP) {
+            folder = new File(this.groupFolder, folderName);
+        } else {
+            folder = new File(this.worldFolder, folderName);
         }
 
         if (!folder.exists()) {
@@ -135,19 +130,26 @@ class FlatFileProfileDataSource implements ProfileDataSource {
      *
      * @param type       Indicates whether data is for group or world.
      * @param dataName   The name of the group or world.
-     * @param playerName The name of the player.
+     * @param player     The OfflinePlayer.
      * @return The data file for a player.
      * @throws IOException if there was a problem creating the file.
      */
-    File getPlayerFile(ContainerType type, String dataName, String playerName) throws IOException {
-        File jsonPlayerFile = new File(this.getFolder(type, dataName), playerName + JSON);
+    File getPlayerFile(ContainerType type, String dataName, OfflinePlayer player) throws IOException {
+        File jsonPlayerFile = new File(this.getFolder(type, dataName), player.getUniqueId().toString() + JSON);
         if (!jsonPlayerFile.exists()) {
+            // TODO: maybe one day we can remove this conversion
+            File oldFile = new File(this.getFolder(type, dataName), player.getName() + JSON);
+            if (oldFile.exists()) {
+                oldFile.renameTo(jsonPlayerFile);
+                if (jsonPlayerFile.exists()) return jsonPlayerFile;
+            }
+
             try {
                 jsonPlayerFile.createNewFile();
             } catch (IOException e) {
                 throw new IOException("Could not create necessary player data file: " + jsonPlayerFile.getPath()
-                        + ". Data for " + playerName + " in " + type.name().toLowerCase() + " " + dataName
-                        + " may not be saved.", e);
+                        + ". Data for Player: " + ((player.getName() != null) ? player.getName() : player.getUniqueId().toString())
+                        + " in " + type.name().toLowerCase() + " " + dataName + " may not be saved.", e);
             }
         }
         return jsonPlayerFile;
@@ -195,7 +197,7 @@ class FlatFileProfileDataSource implements ProfileDataSource {
     private void processProfileWrite(PlayerProfile playerProfile) {
         try {
             File playerFile = this.getPlayerFile(playerProfile.getContainerType(),
-                    playerProfile.getContainerName(), playerProfile.getPlayer().getName());
+                    playerProfile.getContainerName(), playerProfile.getPlayer());
             FileConfiguration playerData = getConfigHandleNow(playerFile);
             playerData.createSection(playerProfile.getProfileType().getName(), serializePlayerProfile(playerProfile));
             try {
@@ -249,7 +251,7 @@ class FlatFileProfileDataSource implements ProfileDataSource {
         }
         File playerFile = null;
         try {
-            playerFile = getPlayerFile(key.getContainerType(), key.getDataName(), key.getPlayerName());
+            playerFile = getPlayerFile(key.getContainerType(), key.getDataName(), Bukkit.getOfflinePlayer(key.getPlayerUUID()));
         } catch (IOException e) {
             e.printStackTrace();
             // Return an empty profile
@@ -276,8 +278,8 @@ class FlatFileProfileDataSource implements ProfileDataSource {
     }
 
     @Override
-    public PlayerProfile getPlayerData(ContainerType containerType, String dataName, ProfileType profileType, UUID playerUUID) {
-        return getPlayerData(ProfileKey.createProfileKey(containerType, dataName, profileType, playerUUID));
+    public PlayerProfile getPlayerData(ContainerType containerType, String dataName, ProfileType profileType, OfflinePlayer player) {
+        return getPlayerData(ProfileKey.createProfileKey(containerType, dataName, profileType, player.getUniqueId()));
     }
 
     private PlayerProfile deserializePlayerProfile(ProfileKey pKey, Map playerData) {
@@ -372,24 +374,26 @@ class FlatFileProfileDataSource implements ProfileDataSource {
      * {@inheritDoc}
      */
     @Override
-    public boolean removePlayerData(ContainerType containerType, String dataName, ProfileType profileType, String playerName) {
+    public boolean removePlayerData(ContainerType containerType, String dataName, ProfileType profileType, OfflinePlayer player) {
         if (profileType == null) {
             try {
-                File playerFile = getPlayerFile(containerType, dataName, playerName);
+                File playerFile = getPlayerFile(containerType, dataName, player);
                 return playerFile.delete();
             } catch (IOException ignore) {
-                Logging.warning("Attempted to delete file that did not exist for player " + playerName
+                Logging.warning("Attempted to delete file that did not exist for Player: "
+                        + ((player.getName() != null) ? player.getName() : player.getUniqueId().toString())
                         + " in " + containerType.name().toLowerCase() + " " + dataName);
                 return false;
             }
         } else {
             File playerFile;
             try {
-                playerFile = getPlayerFile(containerType, dataName, playerName);
+                playerFile = getPlayerFile(containerType, dataName, player);
             } catch (IOException e) {
-                Logging.warning("Attempted to delete " + playerName + "'s data for "
-                        + profileType.getName().toLowerCase() + " mode in "  + containerType.name().toLowerCase()
-                        + " " + dataName + " but the file did not exist.");
+                Logging.warning("Attempted to delete Player: "
+                        + ((player.getName() != null) ? player.getName() : player.getUniqueId().toString())
+                        + "'s data for " + profileType.getName().toLowerCase() + " mode in "
+                        + containerType.name().toLowerCase() + " " + dataName + " but the file did not exist.");
                 return false;
             }
             FileConfiguration playerData = this.waitForConfigHandle(playerFile);
@@ -397,7 +401,8 @@ class FlatFileProfileDataSource implements ProfileDataSource {
             try {
                 playerData.save(playerFile);
             } catch (IOException e) {
-                Logging.severe("Could not delete data for player: " + playerName
+                Logging.severe("Could not delete data for Player: "
+                        + ((player.getName() != null) ? player.getName() : player.getUniqueId().toString())
                         + " for " + containerType.toString() + ": " + dataName);
                 Logging.severe(e.getMessage());
                 return false;
@@ -544,7 +549,7 @@ class FlatFileProfileDataSource implements ProfileDataSource {
     }
 
     @Override
-    public void migratePlayerData(String oldName, String newName, UUID uuid, boolean removeOldData) throws IOException {
+    public void migratePlayerData(OfflinePlayer oldPlayer, OfflinePlayer newPlayer, boolean removeOldData) throws IOException {
         File[] worldFolders = worldFolder.listFiles(File::isDirectory);
         if (worldFolders == null) {
             throw new IOException("Could not enumerate world folders");
@@ -556,28 +561,28 @@ class FlatFileProfileDataSource implements ProfileDataSource {
 
         for (File worldFolder : worldFolders) {
             ProfileKey key = ProfileKey.createProfileKey(ContainerType.WORLD, worldFolder.getName(),
-                    ProfileTypes.ADVENTURE, uuid, oldName);
+                    ProfileTypes.ADVENTURE, newPlayer.getUniqueId(), oldPlayer.getName());
             updatePlayerData(getPlayerData(key));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.CREATIVE)));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.SURVIVAL)));
         }
         for (File groupFolder : groupFolders) {
             ProfileKey key = ProfileKey.createProfileKey(ContainerType.WORLD, groupFolder.getName(),
-                    ProfileTypes.ADVENTURE, uuid, oldName);
+                    ProfileTypes.ADVENTURE, newPlayer.getUniqueId(), oldPlayer.getName());
             updatePlayerData(getPlayerData(key));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.CREATIVE)));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.SURVIVAL)));
         }
         if (removeOldData) {
             for (File worldFolder : worldFolders) {
-                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.ADVENTURE, oldName);
-                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.CREATIVE, oldName);
-                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.SURVIVAL, oldName);
+                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.ADVENTURE, oldPlayer);
+                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.CREATIVE, oldPlayer);
+                removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.SURVIVAL, oldPlayer);
             }
             for (File groupFolder : groupFolders) {
-                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.ADVENTURE, oldName);
-                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.CREATIVE, oldName);
-                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.SURVIVAL, oldName);
+                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.ADVENTURE, oldPlayer);
+                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.CREATIVE, oldPlayer);
+                removePlayerData(ContainerType.GROUP, groupFolder.getName(), ProfileTypes.SURVIVAL, oldPlayer);
             }
         }
     }

--- a/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
@@ -99,28 +99,6 @@ public class InventoriesListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void playerPreLogin(AsyncPlayerPreLoginEvent event) {
-        if (event.getLoginResult() != Result.ALLOWED) {
-            return;
-        }
-        GlobalProfile globalProfile = inventories.getData().getGlobalProfile(event.getName(), event.getUniqueId());
-        if (!globalProfile.getLastKnownName().equalsIgnoreCase(event.getName())) {
-            // Data must be migrated
-            try {
-                inventories.getData().migratePlayerData(globalProfile.getLastKnownName(), event.getName(),
-                        event.getUniqueId(), true);
-            } catch (IOException e) {
-                Logging.severe("Could not migrate data from name " + globalProfile.getLastKnownName()
-                        + " to " + event.getName());
-                e.printStackTrace();
-            }
-
-            globalProfile.setLastKnownName(event.getName());
-            inventories.getData().updateGlobalProfile(globalProfile);
-        }
-    }
-
     /**
      * Called when a player joins the server.
      *

--- a/src/main/java/com/onarandombox/multiverseinventories/WeakProfileContainer.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/WeakProfileContainer.java
@@ -75,7 +75,7 @@ final class WeakProfileContainer implements ProfileContainer {
         PlayerProfile playerProfile = profileMap.get(profileType);
         if (playerProfile == null) {
             playerProfile = getDataSource().getPlayerData(getContainerType(),
-                    getContainerName(), profileType, player.getUniqueId());
+                    getContainerName(), profileType, player);
             Logging.finer("[%s - %s - %s - %s] not cached, loading from disk...",
                     profileType, getContainerType(), playerProfile.getContainerName(), player.getName());
             profileMap.put(profileType, playerProfile);
@@ -91,13 +91,13 @@ final class WeakProfileContainer implements ProfileContainer {
     @Override
     public void removeAllPlayerData(OfflinePlayer player) {
         this.getPlayerData(player.getName()).clear();
-        this.getDataSource().removePlayerData(getContainerType(), getContainerName(), null, player.getName());
+        this.getDataSource().removePlayerData(getContainerType(), getContainerName(), null, player);
     }
 
     @Override
     public void removePlayerData(ProfileType profileType, OfflinePlayer player) {
         this.getPlayerData(player.getName()).remove(profileType);
-        this.getDataSource().removePlayerData(getContainerType(), getContainerName(), profileType, player.getName());
+        this.getDataSource().removePlayerData(getContainerType(), getContainerName(), profileType, player);
     }
 
     @Override

--- a/src/main/java/com/onarandombox/multiverseinventories/command/MigrateCommand.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/command/MigrateCommand.java
@@ -8,6 +8,7 @@ import com.onarandombox.multiverseinventories.profile.container.ProfileContainer
 import com.onarandombox.multiverseinventories.util.Perm;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -32,8 +33,8 @@ public class MigrateCommand extends InventoriesCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        String oldName = args.get(0);
-        String newName = args.get(1);
+        OfflinePlayer oldPlayer = this.plugin.getServer().getOfflinePlayer(args.get(0));
+        OfflinePlayer newPlayer = this.plugin.getServer().getOfflinePlayer(args.get(1));
         boolean deleteOld = true;
         if (args.size() > 2) {
             if (args.get(2).equalsIgnoreCase("saveold")) {
@@ -41,12 +42,12 @@ public class MigrateCommand extends InventoriesCommand {
             }
         }
         try {
-            plugin.getData().migratePlayerData(oldName, newName, Bukkit.getOfflinePlayer(newName).getUniqueId(), deleteOld);
-            messager.good(Message.MIGRATE_SUCCESSFUL, sender, oldName, newName);
+            plugin.getData().migratePlayerData(oldPlayer, newPlayer, deleteOld);
+            messager.good(Message.MIGRATE_SUCCESSFUL, sender, oldPlayer.getName(), newPlayer.getName());
         } catch (IOException e) {
-            Logging.severe("Could not migrate data from name " + oldName + " to " + newName);
+            Logging.severe("Could not migrate data from name " + oldPlayer.getName() + " to " + newPlayer.getName());
             e.printStackTrace();
-            messager.bad(Message.MIGRATE_FAILED, sender, oldName, newName);
+            messager.bad(Message.MIGRATE_FAILED, sender, oldPlayer.getName(), newPlayer.getName());
         }
     }
 }

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/GlobalProfile.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/GlobalProfile.java
@@ -35,13 +35,11 @@ public final class GlobalProfile {
     private final String name;
     private final UUID uuid;
     private String lastWorld = null;
-    private String lastKnownName;
     private boolean loadOnLogin = false;
 
     private GlobalProfile(String name, UUID uuid) {
         this.name = name;
         this.uuid = uuid;
-        this.lastKnownName = name;
     }
 
     /**
@@ -60,26 +58,6 @@ public final class GlobalProfile {
      */
     public UUID getPlayerUUID() {
         return uuid;
-    }
-
-    /**
-     * Returns the last name the player was known to have.
-     *
-     * @return the last name the player was known to have.
-     */
-    public String getLastKnownName() {
-        return lastKnownName;
-    }
-
-    /**
-     * Sets the last name that the player was seen having.
-     * <p>This should be updated when a player's name is changed through Mojang but only after their data has been
-     * migrated to the new name.</p>
-     *
-     * @param lastKnownName the last known name for the player.
-     */
-    public void setLastKnownName(String lastKnownName) {
-        this.lastKnownName = lastKnownName;
     }
 
     /**

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileDataSource.java
@@ -1,6 +1,7 @@
 package com.onarandombox.multiverseinventories.profile;
 
 import com.onarandombox.multiverseinventories.profile.container.ContainerType;
+import org.bukkit.OfflinePlayer;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -13,7 +14,6 @@ public interface ProfileDataSource {
     /**
      * Updates the persisted data for a player for a specific profile.
      *
-     *
      * @param playerProfile The profile for the player that is being updated.
      */
     void updatePlayerData(PlayerProfile playerProfile);
@@ -22,25 +22,25 @@ public interface ProfileDataSource {
      * Retrieves a PlayerProfile from the data source.
      *
      * @param containerType The type of container this profile is part of, world or group.
-     * @param dataName   World/Group to retrieve from.
+     * @param dataName World/Group to retrieve from.
      * @param profileType The type of profile to load data for, typically based on game mode.
-     * @param playerUUID UUID of the player to retrieve for.
-     * @return The player as returned from data.  If no data was found, a new PlayerProfile will be
+     * @param player The OfflinePlayer to retrieve for.
+     * @return The player as returned from data. If no data was found, a new PlayerProfile will be
      *         created.
      */
-    PlayerProfile getPlayerData(ContainerType containerType, String dataName, ProfileType profileType, UUID playerUUID);
+    PlayerProfile getPlayerData(ContainerType containerType, String dataName, ProfileType profileType, OfflinePlayer player);
 
     /**
      * Removes the persisted data for a player for a specific profile.
      *
      * @param containerType The type of container this profile is part of, world or group.
-     * @param dataName   The name of the world/group the player's data is associated with.
-     * @param profileType The type of profile we're removing, as per {@link ProfileType}.  If null, this will remove
+     * @param dataName The name of the world/group the player's data is associated with.
+     * @param profileType The type of profile we're removing, as per {@link ProfileType}. If null, this will remove
      *                    remove all profile types.
-     * @param playerName The name of the player whose data is being removed.
+     * @param player The OfflinePlayer whose data is being removed.
      * @return True if successfully removed.
      */
-    boolean removePlayerData(ContainerType containerType, String dataName, ProfileType profileType, String playerName);
+    boolean removePlayerData(ContainerType containerType, String dataName, ProfileType profileType, OfflinePlayer player);
 
     /**
      * Retrieves the global profile for a player which contains meta-data for the player.
@@ -88,12 +88,11 @@ public interface ProfileDataSource {
     /**
      * Copies all the data belonging to oldName to newName and removes the old data.
      *
-     * @param oldName the previous name of the player.
-     * @param newName the new name of the player.
-     * @param playerUUID the UUID of the player.
-     * @param removeOldData whether or not to remove the data belonging to oldName.
+     * @param oldPlayer The old OfflinePlayer.
+     * @param newPlayer The OfflineProfile we will be migrating data to.
+     * @param removeOldData Whether or not to remove the data belonging to oldName.
      * @throws IOException Thrown if something goes wrong while migrating the files.
      */
-    void migratePlayerData(String oldName, String newName, UUID playerUUID, boolean removeOldData) throws IOException;
+    void migratePlayerData(OfflinePlayer oldPlayer, OfflinePlayer newPlayer, boolean removeOldData) throws IOException;
 }
 

--- a/src/test/java/com/onarandombox/multiverseinventories/FlatFileDataHelper.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/FlatFileDataHelper.java
@@ -2,6 +2,7 @@ package com.onarandombox.multiverseinventories;
 
 import com.onarandombox.multiverseinventories.profile.ProfileDataSource;
 import com.onarandombox.multiverseinventories.profile.container.ContainerType;
+import org.bukkit.OfflinePlayer;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,7 +18,7 @@ public class FlatFileDataHelper {
         this.data = (FlatFileProfileDataSource) data;
     }
 
-    public File getPlayerFile(ContainerType type, String dataName, String playerName) throws IOException {
-        return data.getPlayerFile(type, dataName, playerName);
+    public File getPlayerFile(ContainerType type, String dataName, OfflinePlayer player) throws IOException {
+        return data.getPlayerFile(type, dataName, player);
     }
 }

--- a/src/test/java/com/onarandombox/multiverseinventories/TestWorldChanged.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/TestWorldChanged.java
@@ -7,7 +7,6 @@ import com.onarandombox.multiverseinventories.share.Sharables;
 import com.onarandombox.multiverseinventories.share.Shares;
 import com.onarandombox.multiverseinventories.util.TestInstanceCreator;
 import junit.framework.Assert;
-import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -18,8 +17,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.BookMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPluginLoader;
@@ -34,9 +31,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -196,7 +193,7 @@ public class TestWorldChanged {
 
         Assert.assertEquals(3, inventories.getMVIConfig().getGlobalDebug());
 
-        Player player = inventories.getServer().getPlayer("dumptruckman");
+        Player player = inventories.getServer().getPlayer(UUID.randomUUID());
 
         float satTest = 0.349F;
         player.setSaturation(satTest);
@@ -334,7 +331,7 @@ public class TestWorldChanged {
         Assert.assertNotSame(satTest, player.getSaturation());
 
         FlatFileDataHelper dataHelper = new FlatFileDataHelper(inventories.getData());
-        File playerFile = dataHelper.getPlayerFile(ContainerType.GROUP, "default", "dumptruckman");
+        File playerFile = dataHelper.getPlayerFile(ContainerType.GROUP, "default", player);
         FileConfiguration playerConfig = JsonConfiguration.loadConfiguration(playerFile);
         playerConfig.set("SURVIVAL." + DataStrings.PLAYER_INVENTORY_CONTENTS, null);
         playerConfig.set("SURVIVAL." + DataStrings.PLAYER_ARMOR_CONTENTS, null);


### PR DESCRIPTION
This PR fixes #329 by changing usernames to UUIDs where applicable.

I've included migration code starting at Line 140 in the FlatFileProfileDataSource class, this also removes the need for the PlayerPreLoginEvent which was watching for username changes.