### PR TITLE
Remove TravelAgent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.onarandombox.multiverseinventories</groupId>
     <artifactId>Multiverse-Inventories</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <name>Multiverse-Inventories</name>
     <description>Multiverse Multiworld Inventories Module</description>
     <properties>
@@ -209,7 +209,7 @@ and adjust the build number accordingly -->
         <dependency>
             <groupId>com.onarandombox.multiversecore</groupId>
             <artifactId>Multiverse-Core</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
@@ -25,11 +25,10 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.ServicesManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
-import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.potion.PotionEffectTypeWrapper;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
@@ -262,6 +261,17 @@ public class TestInstanceCreator {
                         }
                     });
             when(mockServer.getScheduler()).thenReturn(mockScheduler);
+
+            // add mock services manager
+            ServicesManager mockServicesManager = mock(ServicesManager.class);
+            when(mockServicesManager.getKnownServices()).
+                    thenAnswer(new Answer<Collection<Class<?>>>() {
+                        @Override
+                        public Collection<Class<?>> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                            return new ArrayList<>();
+                        }
+                    });
+            when(mockServer.getServicesManager()).thenReturn(mockServicesManager);
 
             ItemFactory itemFactory = MockItemMeta.mockItemFactory();
             when(mockServer.getItemFactory()).thenReturn(itemFactory);


### PR DESCRIPTION
This PR removes any usage of TravelAgent from MV Inventories while keeping backwards compatibility.