### PR TITLE
Clear cache on world unload.

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -582,6 +582,11 @@ class FlatFileProfileDataSource implements ProfileDataSource {
         }
     }
 
+    @Override
+    public void clearProfileCache(ProfileKey key) {
+        profileCache.invalidate(key);
+    }
+
     void clearCache() {
         globalProfileCache.invalidateAll();
         profileCache.invalidateAll();

--- a/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
@@ -30,6 +30,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.InventoryHolder;
 import uk.co.tggl.pluckerpluck.multiinv.MultiInv;
 
@@ -442,6 +443,21 @@ public class InventoriesListener implements Listener {
         Logging.finest("Disallowing item or inventory holding %s to go from world %s to world %s since these" +
                         "worlds do not share inventories", entity, fromWorld.getName(), toWorld.getName());
         event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void worldUnload(WorldUnloadEvent event) {
+        String unloadWorldName = event.getWorld().getName();
+
+        Logging.finer("Clearing data for world/groups container with '%s' world.", unloadWorldName);
+
+        ProfileContainer fromWorldProfileContainer = this.inventories.getWorldProfileContainerStore().getContainer(unloadWorldName);
+        fromWorldProfileContainer.clearContainer();
+
+        List<WorldGroup> fromGroups = this.inventories.getGroupManager().getGroupsForWorld(unloadWorldName);
+        for (WorldGroup fromGroup : fromGroups) {
+            fromGroup.getGroupProfileContainer().clearContainer();
+        }
     }
 }
 

--- a/src/main/java/com/onarandombox/multiverseinventories/WeakProfileContainer.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/WeakProfileContainer.java
@@ -2,6 +2,7 @@ package com.onarandombox.multiverseinventories;
 
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.multiverseinventories.profile.ProfileDataSource;
+import com.onarandombox.multiverseinventories.profile.ProfileKey;
 import com.onarandombox.multiverseinventories.profile.WorldGroupManager;
 import com.onarandombox.multiverseinventories.profile.ProfileTypes;
 import com.onarandombox.multiverseinventories.profile.container.ContainerType;
@@ -109,5 +110,14 @@ final class WeakProfileContainer implements ProfileContainer {
     public ContainerType getContainerType() {
         return type;
     }
-}
 
+    @Override
+    public void clearContainer() {
+        for (Map<ProfileType, PlayerProfile> profiles : playerData.values()) {
+            for (PlayerProfile profile : profiles.values()) {
+                this.getDataSource().clearProfileCache(ProfileKey.createProfileKey(profile));
+            }
+        }
+        this.playerData.clear();
+    }
+}

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileDataSource.java
@@ -95,5 +95,10 @@ public interface ProfileDataSource {
      * @throws IOException Thrown if something goes wrong while migrating the files.
      */
     void migratePlayerData(String oldName, String newName, UUID playerUUID, boolean removeOldData) throws IOException;
+
+    /**
+     * Clears a single profile in cache.
+     */
+    void clearProfileCache(ProfileKey key);
 }
 

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileKey.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileKey.java
@@ -34,6 +34,11 @@ public final class ProfileKey {
                 copyKey.getPlayerName());
     }
 
+    public static ProfileKey createProfileKey(PlayerProfile profile) {
+        return new ProfileKey(profile.getContainerType(), profile.getContainerName(), profile.getProfileType(),
+                profile.getPlayer().getUniqueId(), profile.getPlayer().getName());
+    }
+
     private final ContainerType containerType;
     private final String dataName;
     private final ProfileType profileType;

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/container/ProfileContainer.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/container/ProfileContainer.java
@@ -67,5 +67,10 @@ public interface ProfileContainer {
      * @param player Player to remove data for.
      */
     void removePlayerData(ProfileType profileType, OfflinePlayer player);
+
+    /**
+     * Clears all cached data in the container.
+     */
+    void clearContainer();
 }
 


### PR DESCRIPTION
This will prevent issues where old World object is still stored in memory even though it may have been deleted. Fixes #414.