### PR TITLE
Improve negative check for worlds and shares prompt.

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/command/prompts/GroupSharesPrompt.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/command/prompts/GroupSharesPrompt.java
@@ -58,24 +58,23 @@ class GroupSharesPrompt extends InventoriesPrompt {
             plugin.getGroupManager().checkForConflicts(sender);
             return nextPrompt;
         }
+
         boolean negative = false;
-        final Shares shares;
-        if (s.startsWith("-") && s.length() > 1) {
+        Shares shares = Sharables.lookup(s.toLowerCase());
+        if (shares == null && s.startsWith("-") && s.length() > 1) {
             negative = true;
             shares = Sharables.lookup(s.toLowerCase().substring(1));
-        } else {
-            shares = Sharables.lookup(s.toLowerCase());
         }
 
         if (shares == null) {
             messager.normal(Message.ERROR_NO_SHARES_SPECIFIED, sender);
-        } else {
-            if (!negative) {
-                this.shares.addAll(shares);
-            } else {
-                this.shares.removeAll(shares);
-            }
+            return this;
         }
+        if (negative) {
+            this.shares.addAll(shares);
+            return this;
+        }
+        this.shares.removeAll(shares);
         return this;
     }
 }

--- a/src/main/java/com/onarandombox/multiverseinventories/command/prompts/GroupWorldsPrompt.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/command/prompts/GroupWorldsPrompt.java
@@ -61,28 +61,27 @@ class GroupWorldsPrompt extends InventoriesPrompt {
             }
             return nextPrompt;
         }
-        final boolean negative;
-        final World world;
-        if (s.startsWith("-") && s.length() > 1) {
+
+        boolean negative = false;
+        World world = Bukkit.getWorld(s);
+        if (world == null && s.startsWith("-") && s.length() > 1) {
             negative = true;
             world = Bukkit.getWorld(s.substring(1));
-        } else {
-            negative = false;
-            world = Bukkit.getWorld(s);
         }
+
         if (world == null) {
             messager.normal(Message.ERROR_NO_WORLD, sender, s);
-        } else {
-            if (negative) {
-                if (!worlds.contains(world.getName())) {
-                    messager.normal(Message.WORLD_NOT_IN_GROUP, sender, world.getName(), group.getName());
-                    return this;
-                }
-                worlds.remove(world.getName());
-            } else {
-                worlds.add(world.getName());
-            }
+            return this;
         }
+        if (negative) {
+            if (!worlds.contains(world.getName())) {
+                messager.normal(Message.WORLD_NOT_IN_GROUP, sender, world.getName(), group.getName());
+                return this;
+            }
+            worlds.remove(world.getName());
+            return this;
+        }
+        worlds.add(world.getName());
         return this;
     }
 }


### PR DESCRIPTION
Fixes the possible issue where if a world/share name starts with a `-` being always considered negative.