### PR TITLE
Player name change tests and better logging

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -561,13 +561,15 @@ class FlatFileProfileDataSource implements ProfileDataSource {
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.CREATIVE)));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.SURVIVAL)));
         }
+
         for (File groupFolder : groupFolders) {
-            ProfileKey key = ProfileKey.createProfileKey(ContainerType.WORLD, groupFolder.getName(),
+            ProfileKey key = ProfileKey.createProfileKey(ContainerType.GROUP, groupFolder.getName(),
                     ProfileTypes.ADVENTURE, uuid, oldName);
             updatePlayerData(getPlayerData(key));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.CREATIVE)));
             updatePlayerData(getPlayerData(ProfileKey.createProfileKey(key, ProfileTypes.SURVIVAL)));
         }
+
         if (removeOldData) {
             for (File worldFolder : worldFolders) {
                 removePlayerData(ContainerType.WORLD, worldFolder.getName(), ProfileTypes.ADVENTURE, oldName);

--- a/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java
@@ -126,7 +126,6 @@ class FlatFileProfileDataSource implements ProfileDataSource {
         if (!folder.exists()) {
             folder.mkdirs();
         }
-        Logging.finer("got data folder: " + folder.getPath() + " from type: " + type);
         return folder;
     }
 
@@ -150,6 +149,8 @@ class FlatFileProfileDataSource implements ProfileDataSource {
                         + " may not be saved.", e);
             }
         }
+        Logging.finer("got data file: %s. Type: %s, DataName: %s, PlayerName: %s",
+                jsonPlayerFile.getPath(), type, dataName, playerName);
         return jsonPlayerFile;
     }
 
@@ -508,7 +509,7 @@ class FlatFileProfileDataSource implements ProfileDataSource {
         try {
             playerData.save(playerFile);
         } catch (IOException e) {
-            Logging.severe("Could not save global data for player: " + globalProfile.getPlayerName());
+            Logging.severe("Could not save global data for player: " + globalProfile);
             Logging.severe(e.getMessage());
             return false;
         }

--- a/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/InventoriesListener.java
@@ -115,20 +115,26 @@ public class InventoriesListener implements Listener {
         if (event.getLoginResult() != Result.ALLOWED) {
             return;
         }
+
+        Logging.finer("Loading global profile for Player{name:'%s', uuid:'%s'}.",
+                event.getName(), event.getUniqueId());
+
         GlobalProfile globalProfile = inventories.getData().getGlobalProfile(event.getName(), event.getUniqueId());
         if (!globalProfile.getLastKnownName().equalsIgnoreCase(event.getName())) {
             // Data must be migrated
+            Logging.info("Player %s changed name from '%s' to '%s'. Attempting to migrate playerdata...",
+                    event.getUniqueId(), globalProfile.getLastKnownName(), event.getName());
             try {
                 inventories.getData().migratePlayerData(globalProfile.getLastKnownName(), event.getName(),
                         event.getUniqueId(), true);
             } catch (IOException e) {
-                Logging.severe("Could not migrate data from name " + globalProfile.getLastKnownName()
-                        + " to " + event.getName());
+                Logging.severe("An error occurred while trying to migrate playerdata.");
                 e.printStackTrace();
             }
 
             globalProfile.setLastKnownName(event.getName());
             inventories.getData().updateGlobalProfile(globalProfile);
+            Logging.info("Migration complete!");
         }
     }
 

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/GlobalProfile.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/GlobalProfile.java
@@ -32,14 +32,12 @@ public final class GlobalProfile {
         return new GlobalProfile(playerName, playerUUID);
     }
 
-    private final String name;
     private final UUID uuid;
     private String lastWorld = null;
     private String lastKnownName;
     private boolean loadOnLogin = false;
 
     private GlobalProfile(String name, UUID uuid) {
-        this.name = name;
         this.uuid = uuid;
         this.lastKnownName = name;
     }
@@ -48,9 +46,12 @@ public final class GlobalProfile {
      * Returns the name of the player.
      *
      * @return The name of the player.
+     * @deprecated Use {@link #getPlayerUUID()} to uniquely identify a player.
+     *             If you need player name, use {@link #getLastKnownName()}.
      */
+    @Deprecated
     public String getPlayerName() {
-        return this.name;
+        return this.lastKnownName;
     }
 
     /**
@@ -117,5 +118,15 @@ public final class GlobalProfile {
      */
     public void setLastWorld(String world) {
         this.lastWorld = world;
+    }
+
+    @Override
+    public String toString() {
+        return "GlobalProfile{" +
+                "uuid=" + uuid +
+                ", lastWorld='" + lastWorld + '\'' +
+                ", lastKnownName='" + lastKnownName + '\'' +
+                ", loadOnLogin=" + loadOnLogin +
+                '}';
     }
 }

--- a/src/test/java/com/onarandombox/multiverseinventories/TestPlayerNameChange.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/TestPlayerNameChange.java
@@ -1,0 +1,223 @@
+package com.onarandombox.multiverseinventories;
+
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.multiverseinventories.profile.GlobalProfile;
+import com.onarandombox.multiverseinventories.util.MockPlayerFactory;
+import com.onarandombox.multiverseinventories.util.TestInstanceCreator;
+import junit.framework.Assert;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPluginLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MultiverseInventories.class, PluginDescriptionFile.class, JavaPluginLoader.class, MultiverseCore.class})
+@PowerMockIgnore("javax.script.*")
+public class TestPlayerNameChange {
+    TestInstanceCreator creator;
+    Server mockServer;
+    CommandSender mockCommandSender;
+    MultiverseInventories inventories;
+    InventoriesListener listener;
+
+    @Before
+    public void setUp() throws Exception {
+        creator = new TestInstanceCreator();
+        assertTrue(creator.setUp());
+        mockServer = creator.getServer();
+        mockCommandSender = creator.getCommandSender();
+        // Pull a core instance from the server.
+        Plugin plugin = mockServer.getPluginManager().getPlugin("Multiverse-Inventories");
+        // Make sure Core is not null
+        assertNotNull(plugin);
+        inventories = (MultiverseInventories) plugin;
+        Field field = MultiverseInventories.class.getDeclaredField("inventoriesListener");
+        field.setAccessible(true);
+        listener = (InventoriesListener) field.get(inventories);
+        // Make sure Core is enabled
+        assertTrue(inventories.isEnabled());
+
+        Player p = mockServer.getPlayerExact("dumptruckman");
+
+        // Set Player's initial location
+        p.teleport(new Location(mockServer.getWorld("world"), 0, 70, 0));
+
+        // Clear Player's inventory
+        // note: using clear() is not effective!
+        clearInventory(p.getInventory());
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        creator.tearDown();
+    }
+
+    public void changeWorld(Player player, String fromWorld, String toWorld) {
+        Location oldLocation = player.getLocation();
+        Location location = new Location(mockServer.getWorld(toWorld), 0.0, 70.0, 0.0);
+        player.teleport(location);
+        Assert.assertEquals(location, player.getLocation());
+        listener.playerTeleport(new PlayerTeleportEvent(player, oldLocation, location));
+        listener.playerChangedWorld(new PlayerChangedWorldEvent(player, mockServer.getWorld(fromWorld)));
+    }
+
+    public void addToInventory(PlayerInventory inventory, Map<Integer, ItemStack> items) {
+        for (Map.Entry<Integer, ItemStack> invEntry : items.entrySet()) {
+            inventory.setItem(invEntry.getKey(), invEntry.getValue());
+        }
+    }
+
+    public void clearInventory(PlayerInventory inventory) {
+        for (int i = 0; i < inventory.getSize(); i++) {
+            inventory.setItem(i, null);
+        }
+    }
+
+    public static Map<Integer, ItemStack> getFillerInv() {
+        Map<Integer, ItemStack> fillerItems = new HashMap<Integer, ItemStack>();
+        fillerItems.put(3, new ItemStack(Material.BOW, 1));
+        fillerItems.put(13, new ItemStack(Material.DIRT, 64));
+        fillerItems.put(36, new ItemStack(Material.IRON_HELMET, 1));
+        ItemStack book = new ItemStack(Material.WRITTEN_BOOK, 1);
+        fillerItems.put(1, book);
+        ItemStack leather = new ItemStack(Material.LEATHER_BOOTS, 1);
+        fillerItems.put(2, leather);
+        return fillerItems;
+    }
+
+    public static Map<Integer, ItemStack> getFillerInv2() {
+        Map<Integer, ItemStack> fillerItems = new HashMap<Integer, ItemStack>();
+        fillerItems.put(3, new ItemStack(Material.DIAMOND_PICKAXE, 1));
+        fillerItems.put(13, new ItemStack(Material.STONE, 64));
+        fillerItems.put(36, new ItemStack(Material.IRON_HELMET, 1));
+        ItemStack book = new ItemStack(Material.BOOK, 1);
+        fillerItems.put(1, book);
+        ItemStack leather = new ItemStack(Material.GOLDEN_BOOTS, 1);
+        fillerItems.put(2, leather);
+        return fillerItems;
+    }
+
+    public void doPlayerJoin(Player player) throws UnknownHostException {
+        this.listener.playerPreLogin(new AsyncPlayerPreLoginEvent(player.getName(),
+                InetAddress.getLocalHost(), player.getUniqueId()));
+        this.listener.playerJoin(new PlayerJoinEvent(player, null));
+    }
+
+    public void doPlayerQuit(Player player) {
+        this.listener.playerQuit(new PlayerQuitEvent(player, null));
+    }
+
+    public void changePlayerName(Player player, String targetName) {
+        Assert.assertNotNull(player);
+
+        String oldName = player.getName();
+        UUID oldUUID = player.getUniqueId();
+
+        MockPlayerFactory.changeName(player, targetName);
+
+        String newName = player.getName();
+        UUID newUUID = player.getUniqueId();
+
+        Assert.assertEquals(oldName, "dumptruckman");
+        Assert.assertEquals(newName, "benwoo1110");
+        Assert.assertEquals(oldUUID, newUUID);
+    }
+
+    public GlobalProfile getAndCheckGlobalProfile(Player player) {
+        GlobalProfile globalProfile = this.inventories.getData().getGlobalProfile(player.getName(), player.getUniqueId());
+        Assert.assertEquals(globalProfile.getLastKnownName(), player.getName());
+        Assert.assertEquals(globalProfile.getPlayerName(), player.getName());
+        Assert.assertEquals(globalProfile.getPlayerUUID(), player.getUniqueId());
+
+        return globalProfile;
+    }
+
+    /**
+     * Ensure that player data is migrated on name change.
+     */
+    @Test
+    public void TestPlayerNameChangeMigration() throws UnknownHostException {
+        // Initialize a fake command
+        Command mockCommand = mock(Command.class);
+        when(mockCommand.getName()).thenReturn("mvinv");
+
+        Command mockCoreCommand = mock(Command.class);
+        when(mockCoreCommand.getName()).thenReturn("mv");
+
+        // Assert debug mode is off
+        Assert.assertEquals(0, this.inventories.getMVIConfig().getGlobalDebug());
+
+        // Send the debug command.
+        String[] cmdArgs = new String[]{"debug", "3"};
+        this.inventories.onCommand(this.mockCommandSender, mockCoreCommand, "", cmdArgs);
+
+        cmdArgs = new String[]{"reload"};
+        inventories.onCommand(mockCommandSender, mockCommand, "", cmdArgs);
+
+        // Assert debug mode is on
+        Assert.assertEquals(3, inventories.getMVIConfig().getGlobalDebug());
+
+        // Getting player
+        Player player = this.mockServer.getPlayerExact("dumptruckman");
+        Assert.assertNotNull(player);
+
+        doPlayerJoin(player);
+        GlobalProfile globalProfile = getAndCheckGlobalProfile(player);
+
+        // Set inv for world
+        addToInventory(player.getInventory(), getFillerInv());
+        String worldInvData = player.getInventory().toString();
+
+        changeWorld(player, "world", "world2");
+        Assert.assertNotSame(player.getInventory().toString(), worldInvData);
+
+        // Set inv for world2
+        addToInventory(player.getInventory(), getFillerInv2());
+        String world2InvData = player.getInventory().toString();
+
+        doPlayerQuit(player);
+        changePlayerName(player, "benwoo1110");
+        doPlayerJoin(player);
+
+        globalProfile = getAndCheckGlobalProfile(player);
+        Assert.assertNotSame(player.getInventory().toString(), worldInvData);
+        Assert.assertEquals(player.getInventory().toString(), world2InvData);
+
+        // Go back to world2
+        changeWorld(player, "world2", "world_nether");
+        Assert.assertNotSame(player.getInventory().toString(), world2InvData);
+        Assert.assertEquals(player.getInventory().toString(), worldInvData);
+    }
+}

--- a/src/test/java/com/onarandombox/multiverseinventories/util/MockPlayerFactory.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/MockPlayerFactory.java
@@ -76,6 +76,14 @@ public class MockPlayerFactory {
         return createdPlayers.values();
     }
 
+    public static Player changeName(Player player, String newName) {
+        createdPlayers.remove(player.getName());
+        when(player.getName()).thenReturn(newName);
+
+        registerPlayer(player);
+        return player;
+    }
+
     private static void registerPlayer(Player player) {
         createdPlayers.put(player.getName(), player);
         playerUIDs.put(player.getUniqueId(), player);

--- a/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
@@ -384,7 +384,8 @@ public class TestInstanceCreator {
             return false;
         }
 
-        FileUtils.deleteFolder(serverDirectory);
+        // Dont remove so that we can see the data result after the test.
+        // FileUtils.deleteFolder(serverDirectory);
 
         return true;
     }


### PR DESCRIPTION
The fix from #428 should fix player name change issues. This PR is mainly just to add tests and better logging when a player name change occurs.

I deprecated `GlobalProfile#getPlayerName()` as it essentials should be `GlobalProfile#getLastKnownName()`. Since playername may change, it will cause `getPlayerName()` to still reflect the old playername after `LastKnownName` has changed due to a playername change.