### PR TITLE
Add ability to ignore if world exist when adding world to group.

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/command/AddWorldCommand.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/command/AddWorldCommand.java
@@ -1,11 +1,13 @@
 package com.onarandombox.multiverseinventories.command;
 
+import com.onarandombox.commandhandler.CommandHandler;
 import com.onarandombox.multiverseinventories.MultiverseInventories;
 import com.onarandombox.multiverseinventories.WorldGroup;
 import com.onarandombox.multiverseinventories.locale.Message;
 import com.onarandombox.multiverseinventories.util.Perm;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
@@ -20,8 +22,8 @@ public class AddWorldCommand extends InventoriesCommand {
     public AddWorldCommand(MultiverseInventories plugin) {
         super(plugin);
         this.setName("Adds a World to a World Group.");
-        this.setCommandUsage("/mvinv addworld {WORLD} {GROUP}");
-        this.setArgRange(2, 2);
+        this.setCommandUsage("/mvinv addworld {WORLD} {GROUP} [--ignore-exist]");
+        this.setArgRange(2, 3);
         this.addKey("mvinv addworld");
         this.addKey("mvinv addw");
         this.addKey("mvinvaw");
@@ -32,8 +34,8 @@ public class AddWorldCommand extends InventoriesCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        World world = Bukkit.getWorld(args.get(0));
-        if (world == null) {
+        String worldName = args.get(0);
+        if (!CommandHandler.hasFlag("--ignore-exist", args) && Bukkit.getWorld(worldName) == null) {
             this.messager.normal(Message.ERROR_NO_WORLD, sender, args.get(0));
             return;
         }
@@ -42,15 +44,15 @@ public class AddWorldCommand extends InventoriesCommand {
             this.messager.normal(Message.ERROR_NO_GROUP, sender, args.get(1));
             return;
         }
-        if (worldGroup.containsWorld(world.getName())) {
-            this.messager.normal(Message.WORLD_ALREADY_EXISTS, sender, world.getName(),
+        if (worldGroup.containsWorld(worldName)) {
+            this.messager.normal(Message.WORLD_ALREADY_EXISTS, sender, worldName,
                     worldGroup.getName());
             return;
         }
-        worldGroup.addWorld(world);
+        worldGroup.addWorld(worldName);
         this.plugin.getGroupManager().updateGroup(worldGroup);
         this.plugin.getMVIConfig().save();
-        this.messager.normal(Message.WORLD_ADDED, sender, world.getName(),
+        this.messager.normal(Message.WORLD_ADDED, sender, worldName,
                 worldGroup.getName());
     }
 }

--- a/src/main/java/com/onarandombox/multiverseinventories/command/RemoveWorldCommand.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/command/RemoveWorldCommand.java
@@ -1,5 +1,6 @@
 package com.onarandombox.multiverseinventories.command;
 
+import com.onarandombox.commandhandler.CommandHandler;
 import com.onarandombox.multiverseinventories.MultiverseInventories;
 import com.onarandombox.multiverseinventories.WorldGroup;
 import com.onarandombox.multiverseinventories.locale.Message;
@@ -20,8 +21,8 @@ public class RemoveWorldCommand extends InventoriesCommand {
     public RemoveWorldCommand(MultiverseInventories plugin) {
         super(plugin);
         this.setName("Removes a World from a World Group.");
-        this.setCommandUsage("/mvinv removeworld {WORLD} {GROUP}");
-        this.setArgRange(2, 2);
+        this.setCommandUsage("/mvinv removeworld {WORLD} {GROUP} [--ignore-exist]");
+        this.setArgRange(2, 3);
         this.addKey("mvinv removeworld");
         this.addKey("mvinv rmworld");
         this.addKey("mvinv removew");
@@ -36,8 +37,8 @@ public class RemoveWorldCommand extends InventoriesCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        World world = Bukkit.getWorld(args.get(0));
-        if (world == null) {
+        String worldName = args.get(0);
+        if (!CommandHandler.hasFlag("--ignore-exist", args) && Bukkit.getWorld(worldName) == null) {
             this.messager.normal(Message.ERROR_NO_WORLD, sender, args.get(0));
             return;
         }
@@ -46,15 +47,15 @@ public class RemoveWorldCommand extends InventoriesCommand {
             this.messager.normal(Message.ERROR_NO_GROUP, sender, args.get(1));
             return;
         }
-        if (!worldGroup.containsWorld(world.getName())) {
-            this.messager.normal(Message.WORLD_NOT_IN_GROUP, sender, world.getName(),
+        if (!worldGroup.containsWorld(worldName)) {
+            this.messager.normal(Message.WORLD_NOT_IN_GROUP, sender, worldName,
                     worldGroup.getName());
             return;
         }
-        worldGroup.removeWorld(world);
+        worldGroup.removeWorld(worldName);
         this.plugin.getGroupManager().updateGroup(worldGroup);
         this.plugin.getMVIConfig().save();
-        this.messager.normal(Message.WORLD_REMOVED, sender, world.getName(),
+        this.messager.normal(Message.WORLD_REMOVED, sender, worldName,
                 worldGroup.getName());
     }
 }


### PR DESCRIPTION
Fixes #419. There is a possibility that users want to create groups just before creating them. Now, you can do that by running `/mvinv addworld worldname groupname --ignore-exist`. Likewise for removing a world, `/mvinv removeworld worldname groupname --ignore-exist`.