### PR TITLE
Add luckperms context support for worldgroup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@ and adjust the build number accordingly -->
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.onarandombox.multiverseadventure</groupId>
             <artifactId>Multiverse-Adventure</artifactId>
             <version>2.5.0-SNAPSHOT</version>

--- a/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java
@@ -5,6 +5,7 @@ import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVPlugin;
 import com.onarandombox.MultiverseCore.commands.HelpCommand;
 import com.onarandombox.commandhandler.CommandHandler;
+import com.onarandombox.multiverseinventories.dependencies.WorldGroupContextCalculator;
 import com.onarandombox.multiverseinventories.profile.ProfileDataSource;
 import com.onarandombox.multiverseinventories.profile.WorldGroupManager;
 import com.onarandombox.multiverseinventories.profile.container.ContainerType;
@@ -30,6 +31,8 @@ import com.onarandombox.multiverseinventories.locale.Messaging;
 import com.onarandombox.multiverseinventories.migration.ImportManager;
 import com.onarandombox.multiverseinventories.util.Perm;
 import me.drayshak.WorldInventories.WorldInventories;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -174,8 +177,9 @@ public class MultiverseInventories extends JavaPlugin implements MVPlugin, Messa
         // Register Commands
         this.registerCommands();
 
-        // Hook plugins that can be imported from
+        // Hook plugins dependencies
         this.hookImportables();
+        this.hookLuckPerms();
 
         Sharables.init(this);
 
@@ -218,6 +222,22 @@ public class MultiverseInventories extends JavaPlugin implements MVPlugin, Messa
         if (plugin != null) {
             this.getImportManager().hookWorldInventories((WorldInventories) plugin);
         }
+    }
+
+    private void hookLuckPerms() {
+        if (Bukkit.getPluginManager().getPlugin("LuckPerms") == null) {
+            Logging.finer("LuckPerms is not installed on your server.");
+            return;
+        }
+        LuckPerms luckPerms;
+        try {
+            luckPerms = LuckPermsProvider.get();
+        } catch (IllegalArgumentException e) {
+            Logging.warning("Unable to hook into LuckPerms. API not enabled!");
+            Logging.warning(e.getMessage());
+            return;
+        }
+        luckPerms.getContextManager().registerCalculator(new WorldGroupContextCalculator(this));
     }
 
     /**

--- a/src/main/java/com/onarandombox/multiverseinventories/dependencies/WorldGroupContextCalculator.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/dependencies/WorldGroupContextCalculator.java
@@ -1,0 +1,41 @@
+package com.onarandombox.multiverseinventories.dependencies;
+
+import com.onarandombox.multiverseinventories.MultiverseInventories;
+import com.onarandombox.multiverseinventories.WorldGroup;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class WorldGroupContextCalculator implements ContextCalculator<Player> {
+
+    private static final String WORLD_GROUP_CONTEXT_KEY = "mvinv:worldgroup";
+
+    private final MultiverseInventories plugin;
+
+    public WorldGroupContextCalculator(MultiverseInventories plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void calculate(@NotNull Player player, @NotNull ContextConsumer contextConsumer) {
+        ImmutableContextSet.Builder contextBuilder = ImmutableContextSet.builder();
+        this.plugin.getGroupManager()
+                .getGroupsForWorld(player.getWorld().getName())
+                .forEach(worldGroup -> contextBuilder.add(WORLD_GROUP_CONTEXT_KEY, worldGroup.getName()));
+
+        contextConsumer.accept(contextBuilder.build());
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        ImmutableContextSet.Builder contextBuilder = ImmutableContextSet.builder();
+        this.plugin.getGroupManager()
+                .getGroups()
+                .forEach(worldGroup -> contextBuilder.add(WORLD_GROUP_CONTEXT_KEY, worldGroup.getName()));
+
+        return contextBuilder.build();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: maven-version-number
 api-version: 1.13
 author: dumptruckman
 depend: ['Multiverse-Core']
-softdepend: [MultiInv, WorldInventories, Multiverse-Adventure]
+softdepend: [LuckPerms, MultiInv, WorldInventories, Multiverse-Adventure]
 
 commands:
   mvinv:


### PR DESCRIPTION
LuckPerms has a context feature (https://luckperms.net/wiki/Context) which allow you to define permission per world/server etc. This PR add the ability to have permission per-world group which can allow more efficient context setup in some cases. E.g. instead of needing to set 3 context world `survival` `survival_nether` and `survival_the_end`, we can set context 1 for world group `survival`.