### PR TITLE
make it compilable again on Maven 3.8.1 (Fixes #453)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <repositories>
         <repository>
             <id>onarandombox</id>
-            <url>http://repo.onarandombox.com/content/groups/public</url>
+            <url>https://repo.onarandombox.com/content/groups/public</url>
         </repository>
         <repository>
             <id>spigot</id>
@@ -26,7 +26,7 @@
         </repository>
         <repository>
             <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <url>https://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Now compiles again with Maven 3.8.1, on JDK 16:

```
C:\Users\Test\Minecraft\workspace\Multiverse-Inventories>mvn clean package -DskipTests=true
[INFO] Scanning for projects...
[INFO]
[INFO] ---< com.onarandombox.multiverseinventories:Multiverse-Inventories >----
[INFO] Building Multiverse-Inventories 4.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from vault-repo: https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.14.4-R0.1-SNAPSHOT/maven-metadata.xml
[WARNING] Could not transfer metadata org.bukkit:bukkit:1.14.4-R0.1-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.14.4-R0.1-SNAPSHOT/maven-metadata.xml
[WARNING] org.bukkit:bukkit:1.14.4-R0.1-SNAPSHOT/maven-metadata.xmlfailed to transfer from https://nexus.hc.to/content/repositories/pub_releases during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of vault-repo has elapsed or updates are forced. Original error: Could not transfer metadata org.bukkit:bukkit:1.14.4-R0.1-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.14.4-R0.1-SNAPSHOT/maven-metadata.xml
Downloading from vault-repo: https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiversecore/Multiverse-Core/4.1.0-SNAPSHOT/maven-metadata.xml
[WARNING] Could not transfer metadata com.onarandombox.multiversecore:Multiverse-Core:4.1.0-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiversecore/Multiverse-Core/4.1.0-SNAPSHOT/maven-metadata.xml
[WARNING] com.onarandombox.multiversecore:Multiverse-Core:4.1.0-SNAPSHOT/maven-metadata.xmlfailed to transfer from https://nexus.hc.to/content/repositories/pub_releases during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of vault-repo has elapsed or updates are forced. Original error: Could not transfer metadata com.onarandombox.multiversecore:Multiverse-Core:4.1.0-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiversecore/Multiverse-Core/4.1.0-SNAPSHOT/maven-metadata.xml
Downloading from vault-repo: https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiverseadventure/Multiverse-Adventure/2.5.0-SNAPSHOT/maven-metadata.xml
[WARNING] Could not transfer metadata com.onarandombox.multiverseadventure:Multiverse-Adventure:2.5.0-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiverseadventure/Multiverse-Adventure/2.5.0-SNAPSHOT/maven-metadata.xml
[WARNING] com.onarandombox.multiverseadventure:Multiverse-Adventure:2.5.0-SNAPSHOT/maven-metadata.xmlfailed to transfer from https://nexus.hc.to/content/repositories/pub_releases during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of vault-repo has elapsed or updates are forced. Original error: Could not transfer metadata com.onarandombox.multiverseadventure:Multiverse-Adventure:2.5.0-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/com/onarandombox/multiverseadventure/Multiverse-Adventure/2.5.0-SNAPSHOT/maven-metadata.xml
Downloading from vault-repo: https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.8-R0.1-SNAPSHOT/maven-metadata.xml
[WARNING] Could not transfer metadata org.bukkit:bukkit:1.8-R0.1-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.8-R0.1-SNAPSHOT/maven-metadata.xml
[WARNING] org.bukkit:bukkit:1.8-R0.1-SNAPSHOT/maven-metadata.xmlfailed to transfer from https://nexus.hc.to/content/repositories/pub_releases during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of vault-repo has elapsed or updates are forced. Original error: Could not transfer metadata org.bukkit:bukkit:1.8-R0.1-SNAPSHOT/maven-metadata.xml from/to vault-repo (https://nexus.hc.to/content/repositories/pub_releases): transfer failed for https://nexus.hc.to/content/repositories/pub_releases/org/bukkit/bukkit/1.8-R0.1-SNAPSHOT/maven-metadata.xml
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ Multiverse-Inventories ---
[INFO] Deleting C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ Multiverse-Inventories ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ Multiverse-Inventories ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 106 source files to C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\classes
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java: Some input files use or override a deprecated API.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java: Recompile with -Xlint:deprecation for details.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java: Some input files use unchecked or unsafe operations.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/main/java/com/onarandombox/multiverseinventories/FlatFileProfileDataSource.java: Recompile with -Xlint:unchecked for details.
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ Multiverse-Inventories ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\src\test\resources
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ Multiverse-Inventories ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 16 source files to C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\test-classes
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/test/java/com/onarandombox/multiverseinventories/TestResetWorld.java: Some input files use or override a deprecated API.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/test/java/com/onarandombox/multiverseinventories/TestResetWorld.java: Recompile with -Xlint:deprecation for details.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/test/java/com/onarandombox/multiverseinventories/TestWSharableAPI.java: Some input files use unchecked or unsafe operations.
[INFO] /C:/Users/Test/Minecraft/workspace/Multiverse-Inventories/src/test/java/com/onarandombox/multiverseinventories/TestWSharableAPI.java: Recompile with -Xlint:unchecked for details.
[INFO]
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ Multiverse-Inventories ---
[INFO] Tests are skipped.
[INFO]
[INFO] --- maven-replacer-plugin:1.3.8:replace (default) @ Multiverse-Inventories ---
[INFO] Replacement run on 1 file.
[INFO]
[INFO] --- maven-jar-plugin:3.0.2:jar (default-jar) @ Multiverse-Inventories ---
[INFO] Building jar: C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\Multiverse-Inventories-4.0.0-SNAPSHOT.jar
[INFO]
[INFO] --- maven-source-plugin:3.0.1:jar-no-fork (attach-sources) @ Multiverse-Inventories ---
[INFO] Building jar: C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\Multiverse-Inventories-4.0.0-SNAPSHOT-sources.jar
[INFO]
[INFO] --- maven-shade-plugin:3.1.1:shade (default) @ Multiverse-Inventories ---
[INFO] Including com.dumptruckman.minecraft:Logging:jar:1.1.1 in the shaded jar.
[INFO] Including com.feildmaster.lib:EnhancedConfiguration:jar:1.1.3 in the shaded jar.
[INFO] Including com.dumptruckman.minecraft:JsonConfiguration:jar:1.1 in the shaded jar.
[INFO] Including net.minidev:json-smart:jar:1.1.1 in the shaded jar.
[INFO] Including com.googlecode.json-simple:json-simple:jar:1.1.1 in the shaded jar.
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\Multiverse-Inventories-4.0.0-SNAPSHOT.jar with C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\Multiverse-Inventories-4.0.0-SNAPSHOT-shaded.jar
[INFO] Dependency-reduced POM written at: C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\dependency-reduced-pom.xml
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.209 s
[INFO] Finished at: 2021-06-17T16:59:14+02:00
[INFO] ------------------------------------------------------------------------
```

Note that I skipped tests because of a PowerMock internal error:

```
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ Multiverse-Inventories ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.onarandombox.multiverseinventories.TestCommands
[ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.08 s <<< FAILURE! - in null
[ERROR] Test mechanism  Time elapsed: 0.004 s  <<< ERROR!
java.lang.reflect.InaccessibleObjectException: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @67b64c45

[ERROR] Failure when constructing test  Time elapsed: 0.004 s  <<< ERROR!
java.lang.RuntimeException: PowerMock internal error: Should never throw exception at this level
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @2a2b7a35

[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @67b64c45
[ERROR]   PowerMock internal error: Should never throw exception at this level
[INFO]
[ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.677 s
[INFO] Finished at: 2021-06-17T16:58:54+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project Multiverse-Inventories: There are test failures.
[ERROR]
[ERROR] Please refer to C:\Users\Test\Minecraft\workspace\Multiverse-Inventories\target\surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] There was an error in the forked process
[ERROR] Test mechanism :: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @67b64c45
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
[ERROR] Test mechanism :: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @67b64c45
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:657)
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:283)
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:246)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1161)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1002)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:848)
[ERROR]         at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR]         at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR]         at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR]         at org.apache.maven.cli.MavenCli.execute(MavenCli.java:957)
[ERROR]         at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:289)
[ERROR]         at org.apache.maven.cli.MavenCli.main(MavenCli.java:193)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
[ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:567)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
This should be addressed in a separate issue.