### PR TITLE
Ensure stored value of health is never 0.

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/share/Sharables.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/share/Sharables.java
@@ -164,7 +164,12 @@ public final class Sharables implements Shares {
             new SharableHandler<Double>() {
                 @Override
                 public void updateProfile(PlayerProfile profile, Player player) {
-                    profile.set(HEALTH, (double) player.getHealth());
+                    double health = player.getHealth();
+                    // Player is dead, so health should be regained to full.
+                    if (health <= 0) {
+                        health = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+                    }
+                    profile.set(HEALTH, health);
                 }
 
                 @Override


### PR DESCRIPTION
If player is health is 0, assume its dead, so health should be regained to full. Fixes #456

I don't think there is any instance that health wont regain to full on death, so it _shouldnt_ introduce a new behavioural issue.