### PR TITLE
Don't default to ProfileType SURVIVAL for spectator gamemode change.

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
@@ -3,6 +3,7 @@ package com.onarandombox.multiverseinventories;
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.multiverseinventories.event.ShareHandlingEvent;
 import com.onarandombox.multiverseinventories.profile.PlayerProfile;
+import com.onarandombox.multiverseinventories.profile.ProfileTypes;
 import com.onarandombox.multiverseinventories.share.PersistingProfile;
 import com.onarandombox.multiverseinventories.share.Shares;
 import org.bukkit.Bukkit;
@@ -42,7 +43,9 @@ public abstract class ShareHandler {
     }
 
     protected final void setAlwaysWriteProfile(PlayerProfile profile) {
-        affectedProfiles.setAlwaysWriteProfile(profile);
+        if (!profile.getProfileType().equals(ProfileTypes.NONE)) {
+            affectedProfiles.setAlwaysWriteProfile(profile);
+        }
     }
 
     /**
@@ -50,7 +53,9 @@ public abstract class ShareHandler {
      * @param shares    What from this group needs to be saved.
      */
     protected final void addWriteProfile(PlayerProfile profile, Shares shares) {
-        affectedProfiles.addWriteProfile(profile, shares);
+        if (!profile.getProfileType().equals(ProfileTypes.NONE)) {
+            affectedProfiles.addWriteProfile(profile, shares);
+        }
     }
 
     /**
@@ -61,7 +66,9 @@ public abstract class ShareHandler {
      * @param shares    What from this group needs to be loaded.
      */
     protected final void addReadProfile(PlayerProfile profile, Shares shares) {
-        affectedProfiles.addReadProfile(profile, shares);
+        if (!profile.getProfileType().equals(ProfileTypes.NONE)) {
+            affectedProfiles.addReadProfile(profile, shares);
+        }
     }
 
     protected abstract ShareHandlingEvent createEvent();

--- a/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileTypes.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/profile/ProfileTypes.java
@@ -23,6 +23,11 @@ public final class ProfileTypes {
     public static final ProfileType ADVENTURE = ProfileType.createProfileType("ADVENTURE");
 
     /**
+     * The profile type for the any other Game Modes, i.e. spectator.
+     */
+    public static final ProfileType NONE = ProfileType.createProfileType("NONE");
+
+    /**
      * Returns the appropriate ProfileType for the given game mode.
      *
      * @param mode The game mode to get the profile type for.
@@ -37,7 +42,7 @@ public final class ProfileTypes {
             case ADVENTURE:
                 return ADVENTURE;
             default:
-                return SURVIVAL;
+                return NONE;
         }
     }
 


### PR DESCRIPTION
When trying to solve #458, just happened to notice this.

This improves performance slightly as it doesnt rewrite SURVIVAL to SURVIVAL when changing from survival to spectator. There is no need to read or write anything to gamemode spectator.