### PR TITLE
Don't read last_location when teleport type is exact

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/ShareHandler.java
@@ -33,6 +33,7 @@ public abstract class ShareHandler {
      * inventories/stats for a player and persisting the changes.
      */
     final void handleSharing() {
+        TeleportDetails.removeTeleportDestination(this.player);
         ShareHandlingEvent event = this.createEvent();
 
         Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/com/onarandombox/multiverseinventories/TeleportDetails.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/TeleportDetails.java
@@ -1,0 +1,55 @@
+package com.onarandombox.multiverseinventories;
+
+import com.onarandombox.MultiverseCore.api.MVDestination;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A utility class to keep track of currently happening teleportations.
+ * Keeps track of teleport destinations as well the type of destination.
+ */
+public class TeleportDetails {
+    public enum TeleportType {
+        MVTP,
+        OTHER
+    }
+
+    static class TeleportDestination<T> {
+        private final TeleportType type;
+        private final T destination;
+
+        TeleportDestination(TeleportType type, T destination) {
+            this.type = type;
+            this.destination = destination;
+        }
+
+        public TeleportType getType() {
+            return this.type;
+        }
+
+        public T getDestination() {
+            return this.destination;
+        }
+    }
+
+    private final static Map<Player, TeleportDestination<?>> teleportDestinationMap = new HashMap<>();
+
+    public static void addTeleportDestination(Player player, MVDestination mvDestination) {
+        teleportDestinationMap.put(player, new TeleportDestination<>(TeleportType.MVTP, mvDestination));
+    }
+
+    public static void addTeleportDestination(Player player, Location location) {
+        teleportDestinationMap.put(player, new TeleportDestination<>(TeleportType.OTHER, location));
+    }
+
+    public static TeleportDestination<?> getTeleportDestination(Player player) {
+        return teleportDestinationMap.get(player);
+    }
+
+    public static void removeTeleportDestination(Player player) {
+        teleportDestinationMap.remove(player);
+    }
+}


### PR DESCRIPTION
This PR implements the idea I had in #450. I tested it quickly and it seemed to work.

I haven't done any extensive tests, but our unit tests didn't fail... here be dragons, proceed with caution.

Test Build:
[Multiverse-Inventories-4.2.3-SNAPSHOT.jar.zip](https://github.com/Multiverse/Multiverse-Inventories/files/6859586/Multiverse-Inventories-4.2.3-SNAPSHOT.jar.zip)