### PR TITLE
Fix comment duplication in config files on 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
             <url>https://repo.onarandombox.com/content/groups/public</url>
         </repository>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
@@ -173,8 +173,7 @@ and adjust the build number accordingly -->
                             <relocations>
                                 <relocation>
                                     <pattern>com.dumptruckman.minecraft.util.Logging</pattern>
-                                    <shadedPattern>com.onarandombox.multiverseinventories.utils.InvLogging
-                                    </shadedPattern>
+                                    <shadedPattern>com.onarandombox.multiverseinventories.utils.InvLogging</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.dumptruckman.minecraft.util.DebugLog</pattern>
@@ -186,7 +185,11 @@ and adjust the build number accordingly -->
                                 </relocation>
                                 <relocation>
                                     <pattern>net.minidev.json</pattern>
-                                    <shadedPattern>com.onarandombox.multiverseinventories.util.json</shadedPattern>
+                                    <shadedPattern>com.onarandombox.multiverseinventories.utils.json</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.papermc.lib</pattern>
+                                    <shadedPattern>com.onarandombox.multiverseinventories.utils.paperlib</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>
@@ -224,6 +227,12 @@ and adjust the build number accordingly -->
                     <artifactId>craftbukkit</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.7</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.onarandombox.multiverseadventure</groupId>

--- a/src/main/java/com/onarandombox/multiverseinventories/InventoriesConfig.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/InventoriesConfig.java
@@ -4,6 +4,7 @@ import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.multiverseinventories.share.Sharables;
 import com.onarandombox.multiverseinventories.share.Shares;
 import com.onarandombox.multiverseinventories.util.CommentedYamlConfiguration;
+import io.papermc.lib.PaperLib;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.File;
@@ -104,8 +105,8 @@ public final class InventoriesConfig {
         }
     }
 
-    private CommentedYamlConfiguration config;
-    private MultiverseInventories plugin;
+    private final CommentedYamlConfiguration config;
+    private final MultiverseInventories plugin;
 
     InventoriesConfig(MultiverseInventories plugin) throws IOException {
         this.plugin = plugin;
@@ -114,15 +115,17 @@ public final class InventoriesConfig {
             Logging.fine("Created data folder.");
         }
 
-        // Check if the config file exists.  If not, create it.
+        // Check if the config file exists. If not, create it.
         File configFile = new File(plugin.getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
+        boolean configFileExists = configFile.exists();
+        if (!configFileExists) {
             Logging.fine("Created config file.");
             configFile.createNewFile();
         }
 
         // Load the configuration file into memory
-        config = new CommentedYamlConfiguration(configFile, true);
+        boolean supportsCommentsNatively = PaperLib.getMinecraftVersion() > 17;
+        config = new CommentedYamlConfiguration(configFile, !configFileExists || !supportsCommentsNatively);
 
         // Sets defaults config values
         this.setDefaults();

--- a/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/MultiverseInventories.java
@@ -342,8 +342,7 @@ public class MultiverseInventories extends JavaPlugin implements MVPlugin, Messa
     public void reloadConfig() {
         try {
             this.config = new InventoriesConfig(this);
-            this.worldGroupManager = new YamlWorldGroupManager(this, new File(getDataFolder(), "groups.yml"),
-                    ((InventoriesConfig) config).getConfig());
+            this.worldGroupManager = new YamlWorldGroupManager(this, this.config.getConfig());
             this.worldProfileContainerStore = new WeakProfileContainerStore(this, ContainerType.WORLD);
             this.groupProfileContainerStore = new WeakProfileContainerStore(this, ContainerType.GROUP);
 

--- a/src/main/java/com/onarandombox/multiverseinventories/YamlWorldGroupManager.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/YamlWorldGroupManager.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.onarandombox.multiverseinventories.share.Sharables;
 import com.onarandombox.multiverseinventories.util.CommentedYamlConfiguration;
 import com.onarandombox.multiverseinventories.util.DeserializationException;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.configuration.Configuration;
@@ -30,19 +31,21 @@ final class YamlWorldGroupManager extends AbstractWorldGroupManager {
 
     private final CommentedYamlConfiguration groupsConfig;
 
-    YamlWorldGroupManager(final MultiverseInventories inventories, final File groupConfigFile, final Configuration config)
-            throws IOException {
+    YamlWorldGroupManager(final MultiverseInventories inventories, final Configuration config) throws IOException {
         super(inventories);
 
-        // Check if the group config file exists.  If not, create it and migrate group data.
+        // Check if the group config file exists. If not, create it and migrate group data.
+        File groupsConfigFile = new File(plugin.getDataFolder(), "groups.yml");
+        boolean groupsConfigFileExists = groupsConfigFile.exists();
         boolean migrateGroups = false;
-        if (!groupConfigFile.exists()) {
+        if (!groupsConfigFile.exists()) {
             Logging.fine("Created groups file.");
-            groupConfigFile.createNewFile();
+            groupsConfigFile.createNewFile();
             migrateGroups = true;
         }
         // Load the configuration file into memory
-        groupsConfig = new CommentedYamlConfiguration(groupConfigFile, true);
+        boolean supportsCommentsNatively = PaperLib.getMinecraftVersion() > 17;
+        groupsConfig = new CommentedYamlConfiguration(groupsConfigFile, !groupsConfigFileExists || !supportsCommentsNatively);
 
         if (migrateGroups) {
             migrateGroups(config);

--- a/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
@@ -84,12 +84,14 @@ public class TestInstanceCreator {
 
             // Initialize the Mock server.
             mockServer = mock(Server.class);
-            JavaPluginLoader mockPluginLoader = mock(JavaPluginLoader.class);
-            new ReflectionMemberAccessor().set(JavaPluginLoader.class.getDeclaredField("server"), mockPluginLoader, mockServer);
             when(mockServer.getName()).thenReturn("TestBukkit");
             Logger.getLogger("Minecraft").setParent(Util.logger);
             when(mockServer.getLogger()).thenReturn(Util.logger);
             when(mockServer.getWorldContainer()).thenReturn(worldsDirectory);
+
+            // Initialize the Mock Plugin Loader.
+            JavaPluginLoader mockPluginLoader = mock(JavaPluginLoader.class);
+            new ReflectionMemberAccessor().set(JavaPluginLoader.class.getDeclaredField("server"), mockPluginLoader, mockServer);
 
             // Return a fake PDF file.
             PluginDescriptionFile pdf = spy(new PluginDescriptionFile("Multiverse-Inventories", "2.4-test",
@@ -141,12 +143,7 @@ public class TestInstanceCreator {
             world2File.mkdirs();
             MockWorldFactory.makeNewMockWorld("world2", Environment.NORMAL, WorldType.NORMAL);
 
-            // Initialize the Mock server.
-            mockServer = mock(Server.class);
-            when(mockServer.getName()).thenReturn("TestBukkit");
-            Logger.getLogger("Minecraft").setParent(Util.logger);
-            when(mockServer.getLogger()).thenReturn(Util.logger);
-            when(mockServer.getWorldContainer()).thenReturn(worldsDirectory);
+            // Finish initializing.
             when(plugin.getServer()).thenReturn(mockServer);
             when(core.getServer()).thenReturn(mockServer);
             when(mockServer.getPluginManager()).thenReturn(mockPluginManager);

--- a/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/multiverseinventories/util/TestInstanceCreator.java
@@ -85,6 +85,7 @@ public class TestInstanceCreator {
             // Initialize the Mock server.
             mockServer = mock(Server.class);
             when(mockServer.getName()).thenReturn("TestBukkit");
+            when(mockServer.getVersion()).thenReturn("git-TestBukkit-0 (MC: 1.18.1)");
             Logger.getLogger("Minecraft").setParent(Util.logger);
             when(mockServer.getLogger()).thenReturn(Util.logger);
             when(mockServer.getWorldContainer()).thenReturn(worldsDirectory);


### PR DESCRIPTION
This PR fixes comment duplication in config files on 1.18 (#480) by only adding comments when the file is first created.

1.18 adds support for comments, and so it's no longer necessary to add comments every time the server starts. This was the reason for the "duplication" (not actually duplication, it was growing by one line at a time).

Initially I made our wrapper class inherit from YamlConfiguration (which is why I wanted #361 merged, it made that much easier imo), and then I initialized the config objects to either YamlConfiguration or our wrapper class, depending on the server's version. However, I learned afterwards that we still need to add comments when the file is first created, and that is where this solution came from.