### PR TITLE
Remove weird awareness tag in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -106,6 +106,3 @@ commands:
   mvinvd:
     description: Generic Multiverse-Inventories Command
     usage: /<command>
-
-awareness:
-- !@UTF8


### PR DESCRIPTION
Fixes #516

Not sure what the awareness tag does, it's not present in any of plugin.yml documentation.