### PR TITLE
Allow handling of non MV worlds for shares

### DIFF
--- a/src/main/java/com/onarandombox/multiverseinventories/AbstractWorldGroupManager.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/AbstractWorldGroupManager.java
@@ -54,7 +54,7 @@ abstract class AbstractWorldGroupManager implements WorldGroupManager {
         worldName = worldName.toLowerCase();
         List<WorldGroup> worldGroups = new ArrayList<>();
         for (WorldGroup worldGroup : getGroupNames().values()) {
-            if (worldGroup.containsWorld(worldName)) {
+            if (worldGroup.containsWorld(worldName, false)) {
                 worldGroups.add(worldGroup);
             }
         }

--- a/src/main/java/com/onarandombox/multiverseinventories/AbstractWorldGroupManager.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/AbstractWorldGroupManager.java
@@ -58,9 +58,9 @@ abstract class AbstractWorldGroupManager implements WorldGroupManager {
                 worldGroups.add(worldGroup);
             }
         }
-        // Only use the default group for worlds managed by MV-Core
+        // Only use the default group for worlds managed by MV-Core, unless allowed by config
         if (worldGroups.isEmpty() && plugin.getMVIConfig().isDefaultingUngroupedWorlds() &&
-                plugin.getCore().getMVWorldManager().isMVWorld(worldName)) {
+                (plugin.getCore().getMVWorldManager().isMVWorld(worldName) || plugin.getMVIConfig().allowNonMVWorlds())) {
             Logging.finer("Returning default group for world: " + worldName);
             worldGroups.add(getDefaultGroup());
         }

--- a/src/main/java/com/onarandombox/multiverseinventories/InventoriesConfig.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/InventoriesConfig.java
@@ -40,6 +40,11 @@ public final class InventoriesConfig {
          */
         DEFAULT_UNGROUPED_WORLDS("settings.default_ungrouped_worlds", false, "# If set to true, any world not listed in a group will automatically use the settings for the default group!"),
 
+	/**
+	 * Allow worlds not part of Multiverse to be considered ungrouped
+	 */
+        ALLOW_NONMV_WORLDS("settings.allow_nonmv_worlds", false, "# If set to true, any world that isn't imported into MV yet, can be treated as an ungrouped world.  Requires default_ungrouped_worlds to function properly."),
+
         /**
          * Whether or not to save/load player data on log out/in.
          */
@@ -276,6 +281,13 @@ public final class InventoriesConfig {
      */
     public boolean isDefaultingUngroupedWorlds() {
         return this.getBoolean(Path.DEFAULT_UNGROUPED_WORLDS);
+    }
+    
+    /**
+     * @return true if we should handle non-MV worlds also.
+     */
+    public boolean isAllowNonMVWorlds() {
+        return this.getBoolean(Path.ALLOW_NONMV_WORLDS);
     }
 
     /**

--- a/src/main/java/com/onarandombox/multiverseinventories/WorldGroup.java
+++ b/src/main/java/com/onarandombox/multiverseinventories/WorldGroup.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventPriority;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 
 public final class WorldGroup {
 
@@ -174,6 +175,29 @@ public final class WorldGroup {
      * @return True if specified world is part of this group.
      */
     public boolean containsWorld(String worldName) {
+        return this.containsWorld(worldName, true);
+    }
+
+
+    /**
+     * @param worldName Name of world to check for.
+     * @param checkDefaults Check if the world would be part of this group from the default ungrouped world config option.  Needed to avoid a recursion when checking if the world is in any other group
+     * @return True if specified world is part of this group.
+     */
+    public boolean containsWorld(String worldName, boolean checkDefaults) {
+        boolean direct = this.getWorlds().contains(worldName.toLowerCase());
+
+        boolean byDefault = false;
+
+        if (checkDefaults && this.isDefault() && plugin.getMVIConfig().isDefaultingUngroupedWorlds()) {
+            List<WorldGroup> groups = plugin.getGroupManager().getGroupsForWorld(worldName);
+
+            byDefault = !groups.isEmpty();
+        }
+
+        return direct || byDefault;
+
+
         return this.getWorlds().contains(worldName.toLowerCase());
     }
 


### PR DESCRIPTION
This lets you have worlds created by other plugins get treated as a default group world.

You have to set the new `allow_nonmv_worlds` setting to true, along with the `default_ungrouped_worlds` setting.

This makes worlds like the instanced dungeons from EliteMobs, or the dimensionalhome from slimefun "just work" as a default group.

It might be worth expanding this change to let you specify a group instead of only supporting the default group but I didn't see much of a need for it on my server.