### PR TITLE
Fix player name change migration

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/ProfileDataSource.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/ProfileDataSource.java
@@ -93,10 +93,9 @@ public sealed interface ProfileDataSource permits FlatFileProfileDataSource {
      * @param oldName the previous name of the player.
      * @param newName the new name of the player.
      * @param playerUUID the UUID of the player.
-     * @param removeOldData whether or not to remove the data belonging to oldName.
      * @throws IOException Thrown if something goes wrong while migrating the files.
      */
-    void migratePlayerData(String oldName, String newName, UUID playerUUID, boolean removeOldData) throws IOException;
+    void migratePlayerData(String oldName, String newName, UUID playerUUID) throws IOException;
 
     /**
      * Clears a single profile in cache.


### PR DESCRIPTION
I suspect `Bukkit.getOfflinePlayer` method is still returning the object with old player name. So i realise the easiest way around is just migrate by directly rename the `<player>.json` file. The only way this wont work is somehow the player name provided by the Login event is wrong... in that case is not our issue anyways.

Fixes https://github.com/Multiverse/Multiverse-Inventories/issues/329

![image](https://github.com/user-attachments/assets/fad61466-19f8-48e7-b32d-32b6fefa3f7e)
![image](https://github.com/user-attachments/assets/32256dc6-992a-4499-8e9b-5238ea2ab75a)


<!-- artifact-comment-section 561 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-inventories-pr561](https://nightly.link/Multiverse/Multiverse-Inventories/actions/runs/13072267591/multiverse-inventories-pr561.zip)

<!-- artifact-comment-section 561 end (DO NOT EDIT ABOVE) -->