### PR TITLE
Add /mvinv view Command for player inventory inspection across worlds

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -130,7 +130,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                         }
 
                         player.openInventory(inv);
-                        issuer.sendInfo(ChatColor.GREEN + "Opened editable inventory for " + targetPlayer.getName() + " in world " + worldName + ". Changes will save on close.");
+                        issuer.sendInfo(playerInventoryData.status.getFormattedMessage(targetPlayer.getName(), worldName) + ". Changes will save on close.");
                     }); // End of Bukkit.getScheduler().runTask()
                 })
                 .exceptionally(throwable -> {

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -1,11 +1,15 @@
 package org.mvplugins.multiverse.inventories.commands;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.command.MVCommandIssuer;
 import org.mvplugins.multiverse.core.world.MultiverseWorld;
@@ -18,21 +22,27 @@ import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
 import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
+import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
 import org.mvplugins.multiverse.inventories.view.ModifiableInventoryHolder;
+
+import java.util.Arrays;
 
 @Service
 final class InventoryModifyCommand extends InventoriesCommand {
 
     private final InventoryDataProvider inventoryDataProvider;
     private final MultiverseInventories inventories;
+    private final InventoryGUIHelper inventoryGUIHelper;
 
     @Inject
     InventoryModifyCommand(
             @NotNull InventoryDataProvider inventoryDataProvider,
-            @NotNull MultiverseInventories inventories
+            @NotNull MultiverseInventories inventories,
+            @NotNull InventoryGUIHelper inventoryGUIHelper
     ) {
         this.inventoryDataProvider = inventoryDataProvider;
         this.inventories = inventories;
+        this.inventoryGUIHelper = inventoryGUIHelper;
     }
 
     // This method contains the logic for the /mvinv modify command
@@ -92,13 +102,36 @@ final class InventoryModifyCommand extends InventoriesCommand {
                                 inv.setItem(i, playerInventoryData.contents[i]);
                             }
                         }
-                        if (playerInventoryData.armor != null && playerInventoryData.armor.length >= 4) {
+                        // Armor slot mapping for display in the GUI and add fillers if empty
+                        // Slot 39: Helmet
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                        } else {
                             inv.setItem(39, playerInventoryData.armor[0]);
+                        }
+                        // Slot 38: Chestplate
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
+                        } else {
                             inv.setItem(38, playerInventoryData.armor[1]);
+                        }
+                        // Slot 37: Leggings
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
+                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
+                        } else {
                             inv.setItem(37, playerInventoryData.armor[2]);
+                        }
+                        // Slot 36: Boots
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
+                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
+                        } else {
                             inv.setItem(36, playerInventoryData.armor[3]);
                         }
-                        if (playerInventoryData.offHand != null) {
+
+                        // Off-hand slot (40) and add filler if empty
+                        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
+                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
+                        } else {
                             inv.setItem(40, playerInventoryData.offHand);
                         }
 
@@ -113,6 +146,23 @@ final class InventoryModifyCommand extends InventoriesCommand {
                     throwable.printStackTrace();
                     return null; // Must return null for CompletableFuture<Void> in exceptionally
                 });
+    }
+    /**
+     * Helper method to create a filler item for GUI slots.
+     * @param material The material of the filler item.
+     * @param name The display name of the item.
+     * @param lore The lore text for the item.
+     * @return The created ItemStack.
+     */
+    private ItemStack createFillerItem(Material material, String name, String lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.displayName(Component.text(name, NamedTextColor.GOLD)); // Use Component for name
+            meta.lore(Arrays.asList(Component.text(lore, NamedTextColor.GRAY))); // Use Component for lore
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 }
 

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -83,7 +83,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                     Bukkit.getScheduler().runTask(inventories, () -> {
                         // Create inventory with ModifiableInventoryHolder
                         // Pass all necessary context to the holder for saving on close.
-                        Component title = Component.text("Modifiying " + targetPlayer.getName() + " @ " + worldName);
+                        Component title = Component.text("Modify " + targetPlayer.getName() + " @ " + worldName);
                         Inventory inv = Bukkit.createInventory(
                                 new ModifiableInventoryHolder(
                                         targetPlayer,
@@ -91,7 +91,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                                         playerInventoryData.profileTypeUsed, // Use the determined profile type
                                         inventories
                                 ),
-                                54,
+                                45,
                                 title
                         );
 
@@ -131,6 +131,10 @@ final class InventoryModifyCommand extends InventoriesCommand {
                             inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
                         } else {
                             inv.setItem(40, playerInventoryData.offHand);
+                        }
+                        // Add the remaining slots as non-interactable filler items
+                        for (int i = 41; i <= 44; i++) {
+                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
                         }
 
                         viewer.openInventory(inv);

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -1,5 +1,6 @@
 package org.mvplugins.multiverse.inventories.commands;
 
+import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -96,7 +97,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                 .exceptionally(throwable -> {
                     // This block runs if an exception occurs during data loading
                     issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
-                    inventories.getLogger().severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                    Logging.severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
                     throwable.printStackTrace();
                     return null; // Must return null for CompletableFuture<Void> in exceptionally
                 });

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -87,48 +87,8 @@ final class InventoryModifyCommand extends InventoriesCommand {
                                 title
                         );
 
-                        // Fill inventory
-                        if (playerInventoryData.contents != null) {
-                            for (int i = 0; i < Math.min(playerInventoryData.contents.length, 36); i++) {
-                                inv.setItem(i, playerInventoryData.contents[i]);
-                            }
-                        }
-                        // Armor slot mapping for display in the GUI and add fillers if empty
-                        // Slot 36: Helmet
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36, true)); // Use helper
-                        } else {
-                            inv.setItem(36, playerInventoryData.armor[3]);
-                        }
-                        // Slot 37: Chestplate
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37, true)); // Use helper
-                        } else {
-                            inv.setItem(37, playerInventoryData.armor[2]);
-                        }
-                        // Slot 38: Leggings
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38, true)); // Use helper
-                        } else {
-                            inv.setItem(38, playerInventoryData.armor[1]);
-                        }
-                        // Slot 39: Boots
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39, true)); // Use helper
-                        } else {
-                            inv.setItem(39, playerInventoryData.armor[0]);
-                        }
-                        // Off-hand slot (40) and add filler if empty
-                        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
-                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40, true)); // Use helper
-                        } else {
-                            inv.setItem(40, playerInventoryData.offHand);
-                        }
-                        // Add the remaining slots as non-interactable filler items
-                        for (int i = 41; i <= 44; i++) {
-                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i, true));
-                        }
-
+                        // Call the helper method to populate the GUI
+                        inventoryGUIHelper.populateInventoryGUI(inv, playerInventoryData, true);
                         player.openInventory(inv);
                         issuer.sendInfo(playerInventoryData.status.getFormattedMessage(targetPlayer.getName(), worldName) + ". Changes will save on close.");
                     }); // End of Bukkit.getScheduler().runTask()

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -73,6 +73,10 @@ final class InventoryModifyCommand extends InventoriesCommand {
             issuer.sendError(ChatColor.RED + "You must specify a valid player.");
             return;
         }
+        if (viewer.getUniqueId().equals(targetPlayer.getUniqueId())) {
+            issuer.sendError(ChatColor.RED + "You cannot modify your own inventory using this command. Use your regular inventory.");
+            return;
+        }
 
         String worldName = worlds[0].getName();
         // Asynchronously load data using InventoryDataProvider
@@ -103,31 +107,30 @@ final class InventoryModifyCommand extends InventoriesCommand {
                             }
                         }
                         // Armor slot mapping for display in the GUI and add fillers if empty
-                        // Slot 39: Helmet
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
-                        } else {
-                            inv.setItem(39, playerInventoryData.armor[0]);
-                        }
-                        // Slot 38: Chestplate
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
-                        } else {
-                            inv.setItem(38, playerInventoryData.armor[1]);
-                        }
-                        // Slot 37: Leggings
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
-                        } else {
-                            inv.setItem(37, playerInventoryData.armor[2]);
-                        }
-                        // Slot 36: Boots
+                        // Slot 36: Helmet
                         if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
                             inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
                         } else {
                             inv.setItem(36, playerInventoryData.armor[3]);
                         }
-
+                        // Slot 37: Chestplate
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
+                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
+                        } else {
+                            inv.setItem(37, playerInventoryData.armor[2]);
+                        }
+                        // Slot 38: Leggings
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
+                        } else {
+                            inv.setItem(38, playerInventoryData.armor[1]);
+                        }
+                        // Slot 39: Boots
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                        } else {
+                            inv.setItem(39, playerInventoryData.armor[0]);
+                        }
                         // Off-hand slot (40) and add filler if empty
                         if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
                             inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
@@ -146,23 +149,6 @@ final class InventoryModifyCommand extends InventoriesCommand {
                     throwable.printStackTrace();
                     return null; // Must return null for CompletableFuture<Void> in exceptionally
                 });
-    }
-    /**
-     * Helper method to create a filler item for GUI slots.
-     * @param material The material of the filler item.
-     * @param name The display name of the item.
-     * @param lore The lore text for the item.
-     * @return The created ItemStack.
-     */
-    private ItemStack createFillerItem(Material material, String name, String lore) {
-        ItemStack item = new ItemStack(material);
-        ItemMeta meta = item.getItemMeta();
-        if (meta != null) {
-            meta.displayName(Component.text(name, NamedTextColor.GOLD)); // Use Component for name
-            meta.lore(Arrays.asList(Component.text(lore, NamedTextColor.GRAY))); // Use Component for lore
-            item.setItemMeta(meta);
-        }
-        return item;
     }
 }
 

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -81,8 +81,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                                 new ModifiableInventoryHolder(
                                         targetPlayer,
                                         worldName,
-                                        playerInventoryData.profileTypeUsed, // Use the determined profile type
-                                        inventories
+                                        playerInventoryData.profileTypeUsed // Use the determined profile type
                                 ),
                                 45,
                                 title

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -62,11 +62,9 @@ final class InventoryModifyCommand extends InventoriesCommand {
             @Description("The world the player's inventory is in")
             MultiverseWorld world
     ) {
-
         String worldName = world.getName();
         issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
         handleInventoryLoadAndDisplay(issuer, player, targetPlayer, worldName);
-
     }
 
     /**

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -13,6 +13,7 @@ import org.mvplugins.multiverse.core.world.MultiverseWorld;
 import org.mvplugins.multiverse.external.acf.commands.annotation.CommandCompletion;
 import org.mvplugins.multiverse.external.acf.commands.annotation.CommandPermission;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Description;
+import org.mvplugins.multiverse.external.acf.commands.annotation.Flags;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Subcommand;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
@@ -48,32 +49,25 @@ final class InventoryModifyCommand extends InventoriesCommand {
     @Description("Modify a player's inventory in a specific world.")
     void onInventoryModifyCommand(
             @NotNull MVCommandIssuer issuer,
+
+            // to make sure the command is only run by players
+            @Flags("resolve=issuerOnly")
+            @NotNull Player player,
+
             @Syntax("<player>")
             @Description("Online or offline player")
             OfflinePlayer targetPlayer,
 
             @Syntax("<world>")
             @Description("The world the player's inventory is in")
-            MultiverseWorld[] worlds
+            MultiverseWorld world
     ) {
-        if (!(issuer.getIssuer() instanceof Player viewer)) {
-            issuer.sendError(ChatColor.RED + "Only players can modify inventories.");
-            return;
-        }
-        if (worlds == null || worlds.length == 0 || worlds[0] == null) {
-            issuer.sendError(ChatColor.RED + "You must specify a valid world.");
-            return;
-        }
-        if (targetPlayer == null || targetPlayer.getName() == null) {
-            issuer.sendError(ChatColor.RED + "You must specify a valid player.");
-            return;
-        }
-        if (viewer.getUniqueId().equals(targetPlayer.getUniqueId())) {
+        if (player.getUniqueId().equals(targetPlayer.getUniqueId())) {
             issuer.sendError(ChatColor.RED + "You cannot modify your own inventory using this command. Use your regular inventory.");
             return;
         }
 
-        String worldName = worlds[0].getName();
+        String worldName = world.getName();
         // Asynchronously load data using InventoryDataProvider
         issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
 
@@ -137,7 +131,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                             inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
                         }
 
-                        viewer.openInventory(inv);
+                        player.openInventory(inv);
                         issuer.sendInfo(ChatColor.GREEN + "Opened editable inventory for " + targetPlayer.getName() + " in world " + worldName + ". Changes will save on close.");
                     }); // End of Bukkit.getScheduler().runTask()
                 })
@@ -150,4 +144,3 @@ final class InventoryModifyCommand extends InventoriesCommand {
                 });
     }
 }
-

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -67,38 +67,76 @@ final class InventoryModifyCommand extends InventoriesCommand {
         }
 
         String worldName = world.getName();
-        // Asynchronously load data using InventoryDataProvider
         issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
+        handleInventoryLoadAndDisplay(issuer, player, targetPlayer, worldName);
 
+    }
+
+    /**
+     * Handles the asynchronous loading of player inventory data and the display of the GUI.
+     *
+     * @param issuer The command issuer.
+     * @param player The player who will view/modify the inventory.
+     * @param targetPlayer The offline or online player whose inventory data is being loaded.
+     * @param worldName The name of the world for which inventory data is loaded.
+     */
+    private void handleInventoryLoadAndDisplay(
+            @NotNull MVCommandIssuer issuer,
+            @NotNull Player player,
+            @NotNull OfflinePlayer targetPlayer,
+            @NotNull String worldName
+    ) {
         inventoryDataProvider.loadPlayerInventoryData(targetPlayer, worldName)
                 .thenAccept(playerInventoryData -> {
                     // Ensure GUI operations run on the main thread
                     Bukkit.getScheduler().runTask(inventories, () -> {
-                        // Create inventory with ModifiableInventoryHolder
-                        // Pass all necessary context to the holder for saving on close.
-                        String title = "Modify " + targetPlayer.getName() + " @ " + worldName;
-                        Inventory inv = Bukkit.createInventory(
-                                new ModifiableInventoryHolder(
-                                        targetPlayer,
-                                        worldName,
-                                        playerInventoryData.profileTypeUsed // Use the determined profile type
-                                ),
-                                45,
-                                title
-                        );
-
-                        // Call the helper method to populate the GUI
-                        inventoryGUIHelper.populateInventoryGUI(inv, playerInventoryData, true);
-                        player.openInventory(inv);
-                        issuer.sendInfo(playerInventoryData.status.getFormattedMessage(targetPlayer.getName(), worldName) + ". Changes will save on close.");
-                    }); // End of Bukkit.getScheduler().runTask()
+                        createAndOpenGUI(issuer, player, targetPlayer, worldName, playerInventoryData);
+                    });
                 })
                 .exceptionally(throwable -> {
                     // This block runs if an exception occurs during data loading
-                    issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
-                    Logging.severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                    String errorMessage = throwable.getMessage();
+                    if (errorMessage == null || errorMessage.isEmpty()) {
+                        errorMessage = "An unknown error occurred while loading inventory data.";
+                    }
+                    issuer.sendError(ChatColor.RED + errorMessage);
+                    Logging.fine("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
                     throwable.printStackTrace();
-                    return null; // Must return null for CompletableFuture<Void> in exceptionally
+                    return null;
                 });
+    }
+
+    /**
+     * Creates and opens the custom inventory GUI for modification.
+     * This method must be called on the main server thread.
+     *
+     * @param issuer The command issuer.
+     * @param player The player who will view/modify the inventory.
+     * @param targetPlayer The offline player whose inventory is being displayed.
+     * @param worldName The name of the world for which inventory data is displayed.
+     * @param playerInventoryData The loaded inventory data.
+     */
+    private void createAndOpenGUI(
+            @NotNull MVCommandIssuer issuer,
+            @NotNull Player player,
+            @NotNull OfflinePlayer targetPlayer,
+            @NotNull String worldName,
+            @NotNull InventoryDataProvider.PlayerInventoryData playerInventoryData
+    ) {
+        String title = "Modify " + targetPlayer.getName() + " @ " + worldName;
+        Inventory inv = Bukkit.createInventory(
+                new ModifiableInventoryHolder(
+                        targetPlayer,
+                        worldName,
+                        playerInventoryData.profileTypeUsed // Use the determined profile type
+                ),
+                45, // 5 rows for 36 main + 4 armor + 1 off-hand + 4 fillers
+                title
+        );
+
+        // Call the helper method to populate the GUI
+        inventoryGUIHelper.populateInventoryGUI(inv, playerInventoryData, true);
+        player.openInventory(inv);
+        issuer.sendInfo(ChatColor.GREEN + playerInventoryData.status.getFormattedMessage(targetPlayer.getName(), worldName) + ". Changes will save on close.");
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -97,37 +97,37 @@ final class InventoryModifyCommand extends InventoriesCommand {
                         // Armor slot mapping for display in the GUI and add fillers if empty
                         // Slot 36: Helmet
                         if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
+                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36, true)); // Use helper
                         } else {
                             inv.setItem(36, playerInventoryData.armor[3]);
                         }
                         // Slot 37: Chestplate
                         if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
+                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37, true)); // Use helper
                         } else {
                             inv.setItem(37, playerInventoryData.armor[2]);
                         }
                         // Slot 38: Leggings
                         if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38, true)); // Use helper
                         } else {
                             inv.setItem(38, playerInventoryData.armor[1]);
                         }
                         // Slot 39: Boots
                         if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39, true)); // Use helper
                         } else {
                             inv.setItem(39, playerInventoryData.armor[0]);
                         }
                         // Off-hand slot (40) and add filler if empty
                         if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
-                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
+                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40, true)); // Use helper
                         } else {
                             inv.setItem(40, playerInventoryData.offHand);
                         }
                         // Add the remaining slots as non-interactable filler items
                         for (int i = 41; i <= 44; i++) {
-                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
+                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i, true));
                         }
 
                         player.openInventory(inv);

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -3,7 +3,6 @@ package org.mvplugins.multiverse.inventories.commands;
 import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -1,6 +1,5 @@
 package org.mvplugins.multiverse.inventories.commands;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -77,7 +76,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
                     Bukkit.getScheduler().runTask(inventories, () -> {
                         // Create inventory with ModifiableInventoryHolder
                         // Pass all necessary context to the holder for saving on close.
-                        Component title = Component.text("Modify " + targetPlayer.getName() + " @ " + worldName);
+                        String title = "Modify " + targetPlayer.getName() + " @ " + worldName;
                         Inventory inv = Bukkit.createInventory(
                                 new ModifiableInventoryHolder(
                                         targetPlayer,

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -18,9 +18,10 @@ import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
-import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
+import org.mvplugins.multiverse.inventories.view.InventoryDataProvider;
 import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
 import org.mvplugins.multiverse.inventories.view.ModifiableInventoryHolder;
+import org.mvplugins.multiverse.inventories.view.PlayerInventoryData;
 
 @Service
 final class InventoryModifyCommand extends InventoriesCommand {
@@ -126,7 +127,7 @@ final class InventoryModifyCommand extends InventoriesCommand {
             @NotNull Player player,
             @NotNull OfflinePlayer targetPlayer,
             @NotNull String worldName,
-            @NotNull InventoryDataProvider.PlayerInventoryData playerInventoryData
+            @NotNull PlayerInventoryData playerInventoryData
     ) {
         String title = "Modify " + targetPlayer.getName() + " @ " + worldName;
         Inventory inv = Bukkit.createInventory(

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryModifyCommand.java
@@ -1,15 +1,12 @@
 package org.mvplugins.multiverse.inventories.commands;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.command.MVCommandIssuer;
 import org.mvplugins.multiverse.core.world.MultiverseWorld;
@@ -24,8 +21,6 @@ import org.mvplugins.multiverse.inventories.MultiverseInventories;
 import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
 import org.mvplugins.multiverse.inventories.view.ModifiableInventoryHolder;
-
-import java.util.Arrays;
 
 @Service
 final class InventoryModifyCommand extends InventoriesCommand {

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -1,5 +1,6 @@
 package org.mvplugins.multiverse.inventories.commands;
 
+import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -82,7 +83,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                 .exceptionally(throwable -> {
                     // This block runs if an exception occurs during data loading
                     issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
-                    inventories.getLogger().severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                    Logging.severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
                     throwable.printStackTrace();
                     return null; // Must return null for CompletableFuture<Void> in exceptionally
                 });

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.command.MVCommandIssuer;

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -19,8 +19,9 @@ import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
 import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
+import org.mvplugins.multiverse.inventories.view.PlayerInventoryData;
 import org.mvplugins.multiverse.inventories.view.ReadOnlyInventoryHolder;
-import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
+import org.mvplugins.multiverse.inventories.view.InventoryDataProvider;
 
 @Service
 final class InventoryViewCommand extends InventoriesCommand {
@@ -111,7 +112,7 @@ final class InventoryViewCommand extends InventoriesCommand {
             @NotNull Player player,
             @NotNull OfflinePlayer targetPlayer,
             @NotNull String worldName,
-            @NotNull InventoryDataProvider.PlayerInventoryData playerInventoryData
+            @NotNull PlayerInventoryData playerInventoryData
     ) {
         String title = targetPlayer.getName() + " @ " + worldName;
         Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(),

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -95,7 +95,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                 throwable.printStackTrace();
                 return null; // Must return null for CompletableFuture<Void> in exceptionally
             });
-}
+    }
 
     /**
      * Creates and opens the custom inventory GUI for viewing.

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -1,11 +1,12 @@
 package org.mvplugins.multiverse.inventories.commands;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.command.MVCommandIssuer;
 import org.mvplugins.multiverse.core.world.MultiverseWorld;
@@ -17,31 +18,22 @@ import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
-import org.mvplugins.multiverse.inventories.handleshare.SingleShareReader;
-import org.mvplugins.multiverse.inventories.listeners.InventoryViewListener;
-import org.mvplugins.multiverse.inventories.profile.container.ProfileContainer;
-import org.mvplugins.multiverse.inventories.profile.container.ProfileContainerStoreProvider;
-import org.mvplugins.multiverse.inventories.profile.data.PlayerProfile;
-import org.mvplugins.multiverse.inventories.profile.key.ContainerType;
-import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
-import org.mvplugins.multiverse.inventories.profile.key.ProfileTypes;
-import org.mvplugins.multiverse.inventories.share.Sharables;
-
-import java.util.concurrent.CompletionException;
+import org.mvplugins.multiverse.inventories.view.ReadOnlyInventoryHolder;
+import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 
 @Service
-public class InventoryViewCommand extends InventoriesCommand {
+final class InventoryViewCommand extends InventoriesCommand {
 
-    private final ProfileContainerStoreProvider profileContainerStoreProvider;
+    private final InventoryDataProvider inventoryDataProvider;
     private final MultiverseInventories inventories;
 
     @Inject
     InventoryViewCommand(
-            @NotNull ProfileContainerStoreProvider profileContainerStoreProvider,
+            @NotNull InventoryDataProvider inventoryDataProvider,
             @NotNull MultiverseInventories inventories
     ) {
-        this.profileContainerStoreProvider = profileContainerStoreProvider;
         this.inventories = inventories;
+        this.inventoryDataProvider = inventoryDataProvider;
     }
 
     @Subcommand("view")
@@ -80,141 +72,45 @@ public class InventoryViewCommand extends InventoriesCommand {
         }
 
         String worldName = worlds[0].getName();
-        ItemStack[] contents = null;
-        ItemStack[] armor = null;
-        ItemStack offHand = null;
-        String statusMessage;
 
-        // Check if target player is online
-        if (targetPlayer.isOnline()) {
-            Player onlineTarget = targetPlayer.getPlayer();
-            if (onlineTarget != null) {
-                // If the player is online, retrieve their current live inventory
-                contents = onlineTarget.getInventory().getContents();
-                armor = onlineTarget.getInventory().getArmorContents();
-                offHand = onlineTarget.getInventory().getItemInOffHand();
-                statusMessage = "Displaying LIVE inventory for " + targetPlayer.getName() + ".";
-            } else {
-                // Should not happen if isOnline() is true, but as a fallback
-                statusMessage = "Error: Could not get online player instance. Falling back to stored data.";
+        // Asynchronously load data using InventoryDataProvider
+        issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
 
-                // Fallback to stored data if online player instance somehow isn't available
-                // This block is now correctly placed within the 'else' for onlineTarget != null
-                ProfileContainer container = profileContainerStoreProvider.getStore(ContainerType.WORLD)
-                        .getContainer(worldName);
-                if (container == null) {
-                    issuer.sendError(ChatColor.RED + "Could not load profile container for world: " + worldName);
-                    return; // Exit if container cannot be loaded
-                }
-                PlayerProfile tempProfile = container.getPlayerProfileNow(ProfileTypes.SURVIVAL, targetPlayer);
-                ProfileType profileTypeToUse = ProfileTypes.SURVIVAL;
-                if (tempProfile == null) {
-                    for (ProfileType type : ProfileTypes.getTypes()) {
-                        if (type.equals(ProfileTypes.SURVIVAL)) continue;
-                        tempProfile = container.getPlayerProfileNow(type, targetPlayer);
-                        if (tempProfile != null) {
-                            profileTypeToUse = type;
-                            break;
+        inventoryDataProvider.loadPlayerInventoryData(targetPlayer, worldName)
+                .thenAccept(playerInventoryData -> {
+                    //  Ensure GUI operations run on the main thread
+                    Bukkit.getScheduler().runTask(inventories, () -> {
+                        // Create an inventory for viewing.
+                        Component title = Component.text(targetPlayer.getName() + " @ " + worldName);
+                        Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(), 54, title);
+
+                        // Fill in main inventory slots (0–35)
+                        if (playerInventoryData.contents != null) {
+                            for (int i = 0; i < Math.min(playerInventoryData.contents.length, 36); i++) {
+                                inv.setItem(i, playerInventoryData.contents[i]);
+                            }
                         }
-                    }
-                }
-                if (tempProfile == null) {
-                    issuer.sendError(ChatColor.RED + "No player data found for " + targetPlayer.getName() + " in world " + worldName + ". Try checking a different world or ensure the player has played in this world.");
-                    return; // Exit if no profile found
-                }
-                try {
-                    contents = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.INVENTORY).read().join();
-                    armor = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.ARMOR).read().join();
-                    offHand = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.OFF_HAND).read().join();
-                } catch (CompletionException e) {
-                    issuer.sendError(ChatColor.RED + "Error loading inventory data: " + e.getCause().getMessage());
-                    e.printStackTrace();
-                    return; // Exit on loading error
-                }
-                statusMessage = "Displaying STORED inventory for " + targetPlayer.getName() + " in world " + worldName + ". (Fallback)";
-            }
-        } else { // if the target player is offline, load the offline inventory data
+                        // Armor slot mapping for display in the GUI
+                        if (playerInventoryData.armor != null && playerInventoryData.armor.length >= 4) {
+                            inv.setItem(39, playerInventoryData.armor[0]); // Helmet
+                            inv.setItem(38, playerInventoryData.armor[1]); // Chestplate
+                            inv.setItem(37, playerInventoryData.armor[2]); // Leggings
+                            inv.setItem(36, playerInventoryData.armor[3]); // Boots
+                        }
+                        if (playerInventoryData.offHand != null) {
+                            inv.setItem(40, playerInventoryData.offHand);
+                        }
 
-            // Load the container for this world
-            ProfileContainer container = profileContainerStoreProvider.getStore(ContainerType.WORLD)
-                    .getContainer(worldName);
-            if (container == null) {
-                issuer.sendError(ChatColor.RED + "Could not load profile container for world: " + worldName);
-                return; // Exit if container cannot be loaded
-            }
-
-            // Load the targetPlayer's profile key from the container
-            PlayerProfile tempProfile = container.getPlayerProfileNow(ProfileTypes.SURVIVAL, targetPlayer);
-            ProfileType profileTypeToUse = ProfileTypes.SURVIVAL; // Default to SURVIVAL
-
-            if (tempProfile == null) {
-                // If SURVIVAL profile not found, iterate through other known types as a fallback
-                // to find ANY PlayerProfile and use its type.
-                for (ProfileType type : ProfileTypes.getTypes()) {
-                    if (type.equals(ProfileTypes.SURVIVAL)) {
-                        continue; // Skip SURVIVAL as we already tried it
-                    }
-                    tempProfile = container.getPlayerProfileNow(type, targetPlayer);
-                    if (tempProfile != null) {
-                        profileTypeToUse = type; // Use the type of the found profile
-                        break;
-                    }
-                }
-            }
-
-            if (tempProfile == null) {
-                issuer.sendError(ChatColor.RED + "No inventory data found for " + targetPlayer.getName() + " in world " + worldName + ". Try checking a different world or ensure the player has played in this world.");
-                return; // Exit if no profile found
-            }
-
-            try {
-                // Read main inventory contents
-                contents = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.INVENTORY)
-                        .read()
-                        .join(); // Use .join() to block until the future completes
-
-                // Read armor contents
-                armor = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.ARMOR)
-                        .read()
-                        .join();
-
-                // Read off-hand item
-                offHand = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.OFF_HAND)
-                        .read()
-                        .join();
-
-            } catch (CompletionException e) {
-                issuer.sendError(ChatColor.RED + "Error loading inventory data: " + e.getCause().getMessage());
-                e.printStackTrace(); // Log the full stack trace for debugging
-                return; // Exit on loading error
-            }
-            statusMessage = "Displaying STORED inventory for " + targetPlayer.getName() + " in world " + worldName + ".";
-        }
-
-        // Create an inventory for viewing. Size 54 (6 rows) is good for main inventory + armor + offhand.
-        // This links the inventory to our listener, making it read-only.
-        Inventory inv = Bukkit.createInventory(new InventoryViewListener.ReadOnlyInventoryHolder(), 54, targetPlayer.getName() + " @ " + worldName);
-
-        // Fill in main inventory slots (0–35)
-        // Ensure we don't go out of bounds if contents is smaller than expected
-        if (contents != null) {
-            for (int i = 0; i < Math.min(contents.length, 36); i++) {
-                inv.setItem(i, contents[i]);
-            }
-        }
-
-        if (armor != null && armor.length >= 4) {
-            inv.setItem(39, armor[0]); // Helmet (from profile) -> Slot 39 (viewing inv)
-            inv.setItem(38, armor[1]); // Chestplate (from profile) -> Slot 38 (viewing inv)
-            inv.setItem(37, armor[2]); // Leggings (from profile) -> Slot 37 (viewing inv)
-            inv.setItem(36, armor[3]); // Boots (from profile) -> Slot 36 (viewing inv)
-        }
-        // Fill in offhand slot (40)
-        if (offHand != null) {
-            inv.setItem(40, offHand);
-        }
-        // Open the GUI for the viewer
-        viewer.openInventory(inv);
-        issuer.sendInfo(ChatColor.GREEN + statusMessage);
+                        viewer.openInventory(inv);
+                        issuer.sendInfo(ChatColor.GREEN + playerInventoryData.statusMessage);
+                    }); // End of Bukkit.getScheduler().runTask()
+                })
+                .exceptionally(throwable -> {
+                    // This block runs if an exception occurs during data loading
+                    issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
+                    inventories.getLogger().severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                    throwable.printStackTrace();
+                    return null; // Must return null for CompletableFuture<Void> in exceptionally
+                });
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -1,6 +1,5 @@
 package org.mvplugins.multiverse.inventories.commands;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -71,7 +70,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                     //  Ensure GUI operations run on the main thread
                     Bukkit.getScheduler().runTask(inventories, () -> {
                         // Create an inventory for viewing.
-                        Component title = Component.text(targetPlayer.getName() + " @ " + worldName);
+                        String title = targetPlayer.getName() + " @ " + worldName;
                         Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(), 45, title);
 
                         // Fill in main inventory slots (0–35)

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -114,40 +114,7 @@ public class InventoryViewCommand extends InventoriesCommand {
             issuer.sendError("No inventory data found for " + targetPlayer.getName() + " in world " + worldName);
             return;
         }
-/*
-        // Get inventory data
-        var contents = profile.getInventoryContents();
-        var armor = profile.getArmorContents();
-        var offHand = profile.getOffHandItem();
 
-        // Create an inventory for viewing
-        Inventory inv = Bukkit.createInventory(null, 54, targetPlayer.getName() + " @ " + worldName);
-
-        // Fill in inventory slots (0–35)
-        for (int i = 0; i < Math.min(contents.length, 36); i++) {
-            inv.setItem(i, contents[i]);
-        }
-
-// Fill in armor slots (36–39) and offhand (40)
-        if (armor != null && armor.length >= 4) {
-            inv.setItem(39, armor[0]); // Helmet (from profile) -> Slot 39 (viewing inv)
-            inv.setItem(38, armor[1]); // Chestplate (from profile) -> Slot 38 (viewing inv)
-            inv.setItem(37, armor[2]); // Leggings (from profile) -> Slot 37 (viewing inv)
-            inv.setItem(36, armor[3]); // Boots (from profile) -> Slot 36 (viewing inv)
-        }
-
-        // Fill in offhand slot (40)
-        if (offHand != null) {
-            inv.setItem(40, offHand);
-        }
-
-        inv.setItem(40, offHand); // offhand
-
-        // Open the GUI for the viewer
-        viewer.openInventory(inv);
-    }
-}
-*/
         ItemStack[] contents = null;
         ItemStack[] armor = null;
         ItemStack offHand = null;
@@ -186,15 +153,6 @@ public class InventoryViewCommand extends InventoriesCommand {
             }
         }
 
-        // --- Corrected armor slot mapping ---
-        // Bukkit's PlayerInventory armor slots are (from index 0): boots, leggings, chestplate, helmet.
-        // However, Multiverse-Inventories' Sharables.ARMOR returns [helmet, chestplate, leggings, boots].
-        // We need to map them correctly to the viewing inventory's display slots.
-        // Standard viewing inventory layout for armor is:
-        // Slot 36: Boots
-        // Slot 37: Leggings
-        // Slot 38: Chestplate
-        // Slot 39: Helmet
         if (armor != null && armor.length >= 4) {
             inv.setItem(39, armor[0]); // Helmet (from profile) -> Slot 39 (viewing inv)
             inv.setItem(38, armor[1]); // Chestplate (from profile) -> Slot 38 (viewing inv)

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -82,38 +82,38 @@ final class InventoryViewCommand extends InventoriesCommand {
                         // Armor slot mapping for display in the GUI and add fillers if empty
                         // Slot 36: Helmet
                         if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
+                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36, false)); // Use helper
                         } else {
                             inv.setItem(36, playerInventoryData.armor[3]);
                         }
                         // Slot 37: Chestplate
                         if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
+                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37, false)); // Use helper
                         } else {
                             inv.setItem(37, playerInventoryData.armor[2]);
                         }
                         // Slot 38: Leggings
                         if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38, false)); // Use helper
                         } else {
                             inv.setItem(38, playerInventoryData.armor[1]);
                         }
                         // Slot 39: Boots
                         if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39, false)); // Use helper
                         } else {
                             inv.setItem(39, playerInventoryData.armor[0]);
                         }
 
                         // Off-hand slot (40) and add filler if empty
                         if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
-                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
+                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40, false)); // Use helper
                         } else {
                             inv.setItem(40, playerInventoryData.offHand);
                         }
                         // Add the remaining slots as non-interactable filler items
                         for (int i = 41; i <= 44; i++) {
-                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
+                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i, false));
                         }
 
                         player.openInventory(inv);

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -117,7 +117,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                         }
 
                         player.openInventory(inv);
-                        issuer.sendInfo(ChatColor.GREEN + playerInventoryData.statusMessage);
+                        issuer.sendInfo(playerInventoryData.status.getFormattedMessage(targetPlayer.getName(),worldName));
                     }); // End of Bukkit.getScheduler().runTask()
                 })
                 .exceptionally(throwable -> {

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -73,49 +73,8 @@ final class InventoryViewCommand extends InventoriesCommand {
                         String title = targetPlayer.getName() + " @ " + worldName;
                         Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(), 45, title);
 
-                        // Fill in main inventory slots (0–35)
-                        if (playerInventoryData.contents != null) {
-                            for (int i = 0; i < Math.min(playerInventoryData.contents.length, 36); i++) {
-                                inv.setItem(i, playerInventoryData.contents[i]);
-                            }
-                        }
-                        // Armor slot mapping for display in the GUI and add fillers if empty
-                        // Slot 36: Helmet
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36, false)); // Use helper
-                        } else {
-                            inv.setItem(36, playerInventoryData.armor[3]);
-                        }
-                        // Slot 37: Chestplate
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37, false)); // Use helper
-                        } else {
-                            inv.setItem(37, playerInventoryData.armor[2]);
-                        }
-                        // Slot 38: Leggings
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38, false)); // Use helper
-                        } else {
-                            inv.setItem(38, playerInventoryData.armor[1]);
-                        }
-                        // Slot 39: Boots
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39, false)); // Use helper
-                        } else {
-                            inv.setItem(39, playerInventoryData.armor[0]);
-                        }
-
-                        // Off-hand slot (40) and add filler if empty
-                        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
-                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40, false)); // Use helper
-                        } else {
-                            inv.setItem(40, playerInventoryData.offHand);
-                        }
-                        // Add the remaining slots as non-interactable filler items
-                        for (int i = 41; i <= 44; i++) {
-                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i, false));
-                        }
-
+                        // Call the helper method to populate the GUI
+                        inventoryGUIHelper.populateInventoryGUI(inv, playerInventoryData, false);
                         player.openInventory(inv);
                         issuer.sendInfo(playerInventoryData.status.getFormattedMessage(targetPlayer.getName(),worldName));
                     }); // End of Bukkit.getScheduler().runTask()

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -86,7 +86,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                     Bukkit.getScheduler().runTask(inventories, () -> {
                         // Create an inventory for viewing.
                         Component title = Component.text(targetPlayer.getName() + " @ " + worldName);
-                        Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(), 54, title);
+                        Inventory inv = Bukkit.createInventory(new ReadOnlyInventoryHolder(), 45, title);
 
                         // Fill in main inventory slots (0–35)
                         if (playerInventoryData.contents != null) {
@@ -125,6 +125,10 @@ final class InventoryViewCommand extends InventoriesCommand {
                             inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
                         } else {
                             inv.setItem(40, playerInventoryData.offHand);
+                        }
+                        // Add the remaining slots as non-interactable filler items
+                        for (int i = 41; i <= 44; i++) {
+                            inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
                         }
 
                         viewer.openInventory(inv);

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -3,7 +3,6 @@ package org.mvplugins.multiverse.inventories.commands;
 import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -67,35 +67,34 @@ final class InventoryViewCommand extends InventoriesCommand {
         handleInventoryLoadAndDisplay(issuer, player, targetPlayer, worldName);
     }
 
-        /**
-         * Handles the asynchronous loading of player inventory data and the display of the GUI.
-         *
-         * @param issuer The command issuer.
-         * @param player The player who will view the inventory.
-         * @param targetPlayer The offline player whose inventory data is being loaded.
-         * @param worldName The name of the world for which inventory data is loaded.
-         */
-        private void handleInventoryLoadAndDisplay(
-                @NotNull MVCommandIssuer issuer,
-                @NotNull Player player,
-                @NotNull OfflinePlayer targetPlayer,
-                @NotNull String worldName
-    ) {
-        inventoryDataProvider.loadPlayerInventoryData(targetPlayer, worldName)
-                .thenAccept(playerInventoryData -> {
-                    //  Ensure GUI operations run on the main thread
-                    Bukkit.getScheduler().runTask(inventories, () -> {
-                        createAndOpenGUI(issuer, player, targetPlayer, worldName, playerInventoryData);
-                    }); // End of Bukkit.getScheduler().runTask()
-                })
-                .exceptionally(throwable -> {
-                    // This block runs if an exception occurs during data loading
-                    issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
-                    Logging.severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
-                    throwable.printStackTrace();
-                    return null; // Must return null for CompletableFuture<Void> in exceptionally
-                });
-    }
+    /**
+     * Handles the asynchronous loading of player inventory data and the display of the GUI.
+     *
+     * @param issuer The command issuer.
+     * @param player The player who will view the inventory.
+     * @param targetPlayer The offline player whose inventory data is being loaded.
+     * @param worldName The name of the world for which inventory data is loaded.
+     */
+    private void handleInventoryLoadAndDisplay(
+            @NotNull MVCommandIssuer issuer,
+            @NotNull Player player,
+            @NotNull OfflinePlayer targetPlayer,
+            @NotNull String worldName) {
+    inventoryDataProvider.loadPlayerInventoryData(targetPlayer, worldName)
+            .thenAccept(playerInventoryData -> {
+                //  Ensure GUI operations run on the main thread
+                Bukkit.getScheduler().runTask(inventories, () -> {
+                    createAndOpenGUI(issuer, player, targetPlayer, worldName, playerInventoryData);
+                }); // End of Bukkit.getScheduler().runTask()
+            })
+            .exceptionally(throwable -> {
+                // This block runs if an exception occurs during data loading
+                issuer.sendError(ChatColor.RED + "Failed to load inventory data: " + throwable.getMessage());
+                Logging.severe("Error loading inventory for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                throwable.printStackTrace();
+                return null; // Must return null for CompletableFuture<Void> in exceptionally
+            });
+}
 
     /**
      * Creates and opens the custom inventory GUI for viewing.

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -1,0 +1,103 @@
+package org.mvplugins.multiverse.inventories.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.jvnet.hk2.annotations.Service;
+import org.mvplugins.multiverse.core.command.MVCommandIssuer;
+import org.mvplugins.multiverse.core.world.MultiverseWorld;
+import org.mvplugins.multiverse.external.acf.commands.annotation.CommandCompletion;
+import org.mvplugins.multiverse.external.acf.commands.annotation.CommandPermission;
+import org.mvplugins.multiverse.external.acf.commands.annotation.Description;
+import org.mvplugins.multiverse.external.acf.commands.annotation.Subcommand;
+import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
+import org.mvplugins.multiverse.external.jakarta.inject.Inject;
+import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.profile.container.ProfileContainer;
+import org.mvplugins.multiverse.inventories.profile.container.ProfileContainerStoreProvider;
+import org.mvplugins.multiverse.inventories.profile.key.ContainerType;
+
+@Service
+public class InventoryViewCommand extends InventoriesCommand{
+
+    private final ProfileContainerStoreProvider profileContainerStoreProvider;
+    @Inject
+    InventoryViewCommand(
+            @NotNull ProfileContainerStoreProvider profileContainerStoreProvider
+    ) {
+        this.profileContainerStoreProvider = profileContainerStoreProvider;
+    }
+
+    @Subcommand("view")
+    @CommandPermission("multiverse.inventories.view")
+    @CommandCompletion("@players @mvworlds")
+    @Syntax("<player> <world>")
+    @Description("View a player's inventory in a specific world.")
+
+    void onInventoryViewCommand(
+            @NotNull MVCommandIssuer issuer,
+        // TODO add capability for offline players
+            @Syntax("<player>")
+            @Description("Online player")
+            Player target,
+
+            @Syntax("<world>")
+            @Description("The world the player's inventory is in")
+            MultiverseWorld[] worlds
+    ) {
+        if (!(issuer.getIssuer() instanceof Player viewer)) {
+            issuer.sendMessage(ChatColor.RED + "Only players can view inventories.");
+            return;
+        }
+
+        if (worlds == null || worlds.length == 0 || worlds[0] == null) {
+            issuer.sendMessage(ChatColor.RED + "You must specify a valid world.");
+            return;
+        }
+
+
+        String worldName = worlds[0].getName();
+
+        // Load the container for this world
+        ProfileContainer container = profileContainerStoreProvider.getStore(ContainerType.WORLD)
+                .getContainer(worldName);
+
+        if (container == null) {
+            issuer.sendError("Could not load profile container for world: " + worldName);
+            return;
+        }
+
+        // Load the target's profile key from the container
+        var profile = container.getPlayerProfileNow(target);
+        if (profile == null) {
+            issuer.sendError("No inventory data found for " + target.getName() + " in world " + worldName);
+            return;
+        }
+
+        // Get the contents of the player's inventory from the profile
+        ItemStack[] contents = target.getInventory().getContents();     // This is the main inventory (0–35)
+        ItemStack[] armor = target.getInventory().getArmorContents();   // Armor contents (helmet, chest, etc.)
+        ItemStack offHand = target.getInventory().getItemInOffHand();   // Offhand slot
+
+        // Create a new inventory with enough space (you can customize this layout)
+        Inventory inv = Bukkit.createInventory(null, 54, target.getName() + " @ " + worldName);
+
+        // Copy inventory contents into the first 36 slots
+        for (int i = 0; i < contents.length && i < 36; i++) {
+            inv.setItem(i, contents[i]);
+        }
+
+        // Optionally add armor and offhand to specific GUI slots
+        inv.setItem(36, armor.length > 3 ? armor[3] : null); // Boots
+        inv.setItem(37, armor.length > 2 ? armor[2] : null); // Leggings
+        inv.setItem(38, armor.length > 1 ? armor[1] : null); // Chestplate
+        inv.setItem(39, armor.length > 0 ? armor[0] : null); // Helmet
+        inv.setItem(40, offHand);                            // Offhand (shield)
+
+        // Open the GUI for the viewer
+        viewer.openInventory(inv);
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -64,6 +64,7 @@ final class InventoryViewCommand extends InventoriesCommand {
 
         // Asynchronously load data using InventoryDataProvider
         issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
+        handleInventoryLoadAndDisplay(issuer, player, targetPlayer, worldName);
     }
 
         /**

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -95,29 +95,29 @@ final class InventoryViewCommand extends InventoriesCommand {
                             }
                         }
                         // Armor slot mapping for display in the GUI and add fillers if empty
-                        // Slot 39: Helmet
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                        // Slot 36: Helmet
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
+                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
                         } else {
-                            inv.setItem(39, playerInventoryData.armor[0]);
+                            inv.setItem(36, playerInventoryData.armor[3]);
                         }
-                        // Slot 38: Chestplate
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
-                        } else {
-                            inv.setItem(38, playerInventoryData.armor[1]);
-                        }
-                        // Slot 37: Leggings
+                        // Slot 37: Chestplate
                         if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
                             inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
                         } else {
                             inv.setItem(37, playerInventoryData.armor[2]);
                         }
-                        // Slot 36: Boots
-                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
+                        // Slot 38: Leggings
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
                         } else {
-                            inv.setItem(36, playerInventoryData.armor[3]);
+                            inv.setItem(38, playerInventoryData.armor[1]);
+                        }
+                        // Slot 39: Boots
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                        } else {
+                            inv.setItem(39, playerInventoryData.armor[0]);
                         }
 
                         // Off-hand slot (40) and add filler if empty

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -13,6 +13,7 @@ import org.mvplugins.multiverse.core.world.MultiverseWorld;
 import org.mvplugins.multiverse.external.acf.commands.annotation.CommandCompletion;
 import org.mvplugins.multiverse.external.acf.commands.annotation.CommandPermission;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Description;
+import org.mvplugins.multiverse.external.acf.commands.annotation.Flags;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Subcommand;
 import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
@@ -48,34 +49,19 @@ final class InventoryViewCommand extends InventoriesCommand {
     void onInventoryViewCommand(
             @NotNull MVCommandIssuer issuer,
 
+            // Ensure the command is run by a player
+            @Flags("resolve=issuerOnly")
+            @NotNull Player player,
+
             @Syntax("<player>")
             @Description("Online or offline player")
-            //Player targetPlayer,
             OfflinePlayer targetPlayer,
 
             @Syntax("<world>")
             @Description("The world the player's inventory is in")
-            MultiverseWorld[] worlds
+            MultiverseWorld world
     ) {
-        // Check if the command sender is a player
-        if (!(issuer.getIssuer() instanceof Player viewer)) {
-            issuer.sendError(ChatColor.RED + "Only players can view inventories.");
-            return;
-        }
-
-        // Validate world argument
-        if (worlds == null || worlds.length == 0 || worlds[0] == null) {
-            issuer.sendError(ChatColor.RED + "You must specify a valid world.");
-            return;
-        }
-
-        // Validate targetPlayer player
-        if (targetPlayer == null || targetPlayer.getName() == null) {
-            issuer.sendError(ChatColor.RED + "You must specify a valid player.");
-            return;
-        }
-
-        String worldName = worlds[0].getName();
+        String worldName = world.getName();
 
         // Asynchronously load data using InventoryDataProvider
         issuer.sendInfo(ChatColor.YELLOW + "Loading inventory data for " + targetPlayer.getName() + "...");
@@ -131,7 +117,7 @@ final class InventoryViewCommand extends InventoriesCommand {
                             inv.setItem(i, inventoryGUIHelper.createFillerItemForSlot(i));
                         }
 
-                        viewer.openInventory(inv);
+                        player.openInventory(inv);
                         issuer.sendInfo(ChatColor.GREEN + playerInventoryData.statusMessage);
                     }); // End of Bukkit.getScheduler().runTask()
                 })

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/InventoryViewCommand.java
@@ -3,6 +3,7 @@ package org.mvplugins.multiverse.inventories.commands;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -17,6 +18,7 @@ import org.mvplugins.multiverse.external.acf.commands.annotation.Syntax;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
 import org.mvplugins.multiverse.inventories.view.ReadOnlyInventoryHolder;
 import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 
@@ -25,14 +27,17 @@ final class InventoryViewCommand extends InventoriesCommand {
 
     private final InventoryDataProvider inventoryDataProvider;
     private final MultiverseInventories inventories;
+    private final InventoryGUIHelper inventoryGUIHelper;
 
     @Inject
     InventoryViewCommand(
             @NotNull InventoryDataProvider inventoryDataProvider,
-            @NotNull MultiverseInventories inventories
+            @NotNull MultiverseInventories inventories,
+            @NotNull InventoryGUIHelper inventoryGUIHelper
     ) {
         this.inventories = inventories;
         this.inventoryDataProvider = inventoryDataProvider;
+        this.inventoryGUIHelper = inventoryGUIHelper;
     }
 
     @Subcommand("view")
@@ -89,14 +94,36 @@ final class InventoryViewCommand extends InventoriesCommand {
                                 inv.setItem(i, playerInventoryData.contents[i]);
                             }
                         }
-                        // Armor slot mapping for display in the GUI
-                        if (playerInventoryData.armor != null && playerInventoryData.armor.length >= 4) {
-                            inv.setItem(39, playerInventoryData.armor[0]); // Helmet
-                            inv.setItem(38, playerInventoryData.armor[1]); // Chestplate
-                            inv.setItem(37, playerInventoryData.armor[2]); // Leggings
-                            inv.setItem(36, playerInventoryData.armor[3]); // Boots
+                        // Armor slot mapping for display in the GUI and add fillers if empty
+                        // Slot 39: Helmet
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
+                            inv.setItem(39, inventoryGUIHelper.createFillerItemForSlot(39)); // Use helper
+                        } else {
+                            inv.setItem(39, playerInventoryData.armor[0]);
                         }
-                        if (playerInventoryData.offHand != null) {
+                        // Slot 38: Chestplate
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
+                            inv.setItem(38, inventoryGUIHelper.createFillerItemForSlot(38)); // Use helper
+                        } else {
+                            inv.setItem(38, playerInventoryData.armor[1]);
+                        }
+                        // Slot 37: Leggings
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
+                            inv.setItem(37, inventoryGUIHelper.createFillerItemForSlot(37)); // Use helper
+                        } else {
+                            inv.setItem(37, playerInventoryData.armor[2]);
+                        }
+                        // Slot 36: Boots
+                        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
+                            inv.setItem(36, inventoryGUIHelper.createFillerItemForSlot(36)); // Use helper
+                        } else {
+                            inv.setItem(36, playerInventoryData.armor[3]);
+                        }
+
+                        // Off-hand slot (40) and add filler if empty
+                        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
+                            inv.setItem(40, inventoryGUIHelper.createFillerItemForSlot(40)); // Use helper
+                        } else {
                             inv.setItem(40, playerInventoryData.offHand);
                         }
 

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -56,77 +56,81 @@ final class InventoryViewListener implements MVInvListener {
         }
 
         // If it's a modifiable inventory, apply specific restrictions for armor/off-hand slots.
-        if (event.getInventory().getHolder() instanceof ModifiableInventoryHolder) {
-            int clickedSlot = event.getRawSlot();
-            ItemStack cursorItem = event.getCursor(); // Item held by the cursor
-            ItemStack currentItem = event.getCurrentItem(); // Item in the clicked slot
-            Player player = (Player) event.getWhoClicked(); // The player who clicked
+        if (!(event.getInventory().getHolder() instanceof ModifiableInventoryHolder)) {
+            return;
+        }
 
-            // Define the special slots
-            boolean isSpecialSlot =  (clickedSlot >= 36 && clickedSlot <= 40); // Armor (36-39) and Off-hand (40)
+        int clickedSlot = event.getRawSlot();
+        ItemStack cursorItem = event.getCursor(); // Item held by the cursor
+        ItemStack currentItem = event.getCurrentItem(); // Item in the clicked slot
+        Player player = (Player) event.getWhoClicked(); // The player who clicked
 
-            // Determine if the slot is one of the padding slots (41-44)
-            boolean isPaddingSlot =  (clickedSlot >= 41 && clickedSlot <= 44);
+        // Define the special slots
+        boolean isSpecialSlot =  (clickedSlot >= 36 && clickedSlot <= 40); // Armor (36-39) and Off-hand (40)
 
-            if (isPaddingSlot) {
-                // Clicks on padding slots are always cancelled and do nothing else.
-                event.setCancelled(true);
-                return;
+        // Determine if the slot is one of the padding slots (41-44)
+        boolean isPaddingSlot =  (clickedSlot >= 41 && clickedSlot <= 44);
+
+        if (isPaddingSlot) {
+            // Clicks on padding slots are always cancelled and do nothing else.
+            event.setCancelled(true);
+            return;
+        }
+
+        // --- Logic for special slots (armor/off-hand) ---
+        if (!isSpecialSlot) {
+            return;
+        }
+
+        boolean currentItemIsFiller = currentItem != null && inventoryGUIHelper.isFillerItem(currentItem);
+
+        // Scenario 1: Player tries to pick up a filler item (cursor is empty)
+        if (currentItemIsFiller && (cursorItem == null || cursorItem.getType() == Material.AIR)) {
+            event.setCancelled(true);
+            return; // Prevent pickup, filler stays in place
+        }
+
+        // Scenario 2: Player tries to place an invalid item into a special slot
+        if (cursorItem != null && cursorItem.getType() != Material.AIR && !inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
+            event.setCancelled(true);
+            return; // Prevent invalid placement
+        }
+
+        // Scenario 3: Player places a valid item into a special slot that currently holds a filler or a valid item.
+        // Manually handle the swap to ensure fillers don't leave the GUI.
+        if (cursorItem != null && cursorItem.getType() != Material.AIR && inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
+            event.setCancelled(true); // Take full control of the event
+
+            // Place the new item from the cursor into the clicked slot
+            event.getInventory().setItem(clickedSlot, cursorItem);
+
+            // If the player tries to replace an item in the filler slot, check if the item is valid.
+            if (currentItem != null && currentItem.getType() != Material.AIR && !inventoryGUIHelper.isFillerItem(currentItem)) {
+                // If the original item was a real, non-filler item, put it on the player's cursor.
+                player.setItemOnCursor(currentItem);
+            } else {
+                // If the original item was null, air, or a filler, clear the player's cursor.
+                player.setItemOnCursor(null);
             }
 
-            // --- Logic for special slots (armor/off-hand) ---
-            if (isSpecialSlot) {
-                boolean currentItemIsFiller = currentItem != null && inventoryGUIHelper.isFillerItem(currentItem);
+            player.updateInventory(); // Update client to reflect changes
+            return; // Event handled
+        }
 
-                // Scenario 1: Player tries to pick up a filler item (cursor is empty)
-                if (currentItemIsFiller && (cursorItem == null || cursorItem.getType() == Material.AIR)) {
-                    event.setCancelled(true);
-                    return; // Prevent pickup, filler stays in place
+        // Scenario 4: Player is shift-clicking a valid item from a special slot.
+        // Or picking up a valid item from a special slot.
+        // We need to ensure filler reappears if the slot becomes empty.
+        if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY ||
+                event.getAction() == InventoryAction.PICKUP_ALL ||
+                event.getAction() == InventoryAction.PICKUP_HALF ||
+                event.getAction() == InventoryAction.PICKUP_ONE ||
+                event.getAction() == InventoryAction.PICKUP_SOME) {
+            Bukkit.getScheduler().runTaskLater(inventories, () -> {
+                // After Bukkit processes the click, if the slot is now empty, put the filler back.
+                if (event.getInventory().getItem(clickedSlot) == null || event.getInventory().getItem(clickedSlot).getType() == Material.AIR) {
+                    event.getInventory().setItem(clickedSlot, inventoryGUIHelper.createFillerItemForSlot(clickedSlot, true));
                 }
-
-                // Scenario 2: Player tries to place an invalid item into a special slot
-                if (cursorItem != null && cursorItem.getType() != Material.AIR && !inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
-                    event.setCancelled(true);
-                    return; // Prevent invalid placement
-                }
-
-                // Scenario 3: Player places a valid item into a special slot that currently holds a filler or a valid item.
-                // Manually handle the swap to ensure fillers don't leave the GUI.
-                if (cursorItem != null && cursorItem.getType() != Material.AIR && inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
-                    event.setCancelled(true); // Take full control of the event
-
-                    // Place the new item from the cursor into the clicked slot
-                    event.getInventory().setItem(clickedSlot, cursorItem);
-
-                    // If the player tries to replace an item in the filler slot, check if the item is valid.
-                    if (currentItem != null && currentItem.getType() != Material.AIR && !inventoryGUIHelper.isFillerItem(currentItem)) {
-                        // If the original item was a real, non-filler item, put it on the player's cursor.
-                        player.setItemOnCursor(currentItem);
-                    } else {
-                        // If the original item was null, air, or a filler, clear the player's cursor.
-                        player.setItemOnCursor(null);
-                    }
-
-                    player.updateInventory(); // Update client to reflect changes
-                    return; // Event handled
-                }
-
-                // Scenario 4: Player is shift-clicking a valid item from a special slot.
-                // Or picking up a valid item from a special slot.
-                // We need to ensure filler reappears if the slot becomes empty.
-                if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY ||
-                        event.getAction() == InventoryAction.PICKUP_ALL ||
-                        event.getAction() == InventoryAction.PICKUP_HALF ||
-                        event.getAction() == InventoryAction.PICKUP_ONE ||
-                        event.getAction() == InventoryAction.PICKUP_SOME) {
-                    Bukkit.getScheduler().runTaskLater(inventories, () -> {
-                        // After Bukkit processes the click, if the slot is now empty, put the filler back.
-                        if (event.getInventory().getItem(clickedSlot) == null || event.getInventory().getItem(clickedSlot).getType() == Material.AIR) {
-                            event.getInventory().setItem(clickedSlot, inventoryGUIHelper.createFillerItemForSlot(clickedSlot, true));
-                        }
-                    }, 1L);
-                }
-            }
+            }, 1L);
         }
     }
 
@@ -140,44 +144,45 @@ final class InventoryViewListener implements MVInvListener {
         }
 
         // If it's a modifiable inventory, apply specific restrictions for armor/off-hand slots.
-        if (event.getInventory().getHolder() instanceof ModifiableInventoryHolder) {
-            ItemStack draggedItem = event.getCursor(); // The item being dragged (after the drag operation)
+        if (!(event.getInventory().getHolder() instanceof ModifiableInventoryHolder)) {
+            return;
+        }
 
-            // If nothing is being dragged, or dragging air, no restriction needed.
-            if (draggedItem == null || draggedItem.getType() == Material.AIR) {
+        ItemStack draggedItem = event.getCursor(); // The item being dragged (after the drag operation)
+
+        // If nothing is being dragged, or dragging air, no restriction needed.
+        if (draggedItem == null || draggedItem.getType() == Material.AIR) {
+            return;
+        }
+
+        for (int slot : event.getRawSlots()) {
+            // Define the special slots
+            boolean isSpecialSlot = (slot >= 36 && slot <= 40);
+
+            // Determine if the slot is one of the padding slots (41-44)
+            boolean isPaddingSlot = (slot >= 41 && slot <= 44);
+
+            if (isPaddingSlot) {
+                // Clicks on padding slots are always cancelled and do nothing else.
+                event.setCancelled(true);
                 return;
             }
+
+            // Check if the dragged item is valid for this special slot
+            if (isSpecialSlot && !inventoryGUIHelper.isValidItemForSlot(draggedItem, slot)) {
+                event.setCancelled(true);
+                return; // Cancel the entire drag event
+            }
+        }
+
+        // After a drag, check if any special slots became empty and replace with filler
+        Bukkit.getScheduler().runTaskLater(inventories, () -> {
             for (int slot : event.getRawSlots()) {
-                // Define the special slots
-                boolean isSpecialSlot = (slot >= 36 && slot <= 40);
-
-                // Determine if the slot is one of the padding slots (41-44)
-                boolean isPaddingSlot = (slot >= 41 && slot <= 44);
-
-                if (isPaddingSlot) {
-                    // Clicks on padding slots are always cancelled and do nothing else.
-                    event.setCancelled(true);
-                    return;
-                }
-
-                if (isSpecialSlot) {
-                    // Check if the dragged item is valid for this special slot
-                    if (!inventoryGUIHelper.isValidItemForSlot(draggedItem, slot)) { // Use helper
-                        event.setCancelled(true);
-                        return; // Cancel the entire drag event
-                    }
+                if ((slot >= 36 && slot <= 40) && (event.getInventory().getItem(slot) == null || event.getInventory().getItem(slot).getType() == Material.AIR)) {
+                    event.getInventory().setItem(slot, inventoryGUIHelper.createFillerItemForSlot(slot, true)); // Use helper
                 }
             }
-
-            // After a drag, check if any special slots became empty and replace with filler
-            Bukkit.getScheduler().runTaskLater(inventories, () -> {
-                for (int slot : event.getRawSlots()) {
-                    if ((slot >= 36 && slot <= 40) && (event.getInventory().getItem(slot) == null || event.getInventory().getItem(slot).getType() == Material.AIR)) {
-                        event.getInventory().setItem(slot, inventoryGUIHelper.createFillerItemForSlot(slot, true)); // Use helper
-                    }
-                }
-            }, 1L); // Run one tick later
-        }
+        }, 1L); // Run one tick later
     }
 
     // Event handler for InventoryCloseEvent to save changes
@@ -185,46 +190,48 @@ final class InventoryViewListener implements MVInvListener {
     @DefaultEventPriority(EventPriority.NORMAL)
     void onInventoryClose(InventoryCloseEvent event) {
         // Check if the closed inventory has the custom ModifiableInventoryHolder class
-        if (event.getInventory().getHolder() instanceof ModifiableInventoryHolder holder) {
-            final OfflinePlayer targetPlayer = holder.getTargetPlayer();
-            final String worldName = holder.getWorldName();
-            final ProfileType profileType = holder.getProfileType();
-            final Inventory closedInventory = event.getInventory();
-
-            // Extract contents: 0-35 for inventory, 36-39 for armor, 40 for off-hand
-            ItemStack[] newContents = Arrays.copyOfRange(closedInventory.getContents(), 0, 36);
-            ItemStack[] newArmor = new ItemStack[4];
-            // Map GUI armor slots back to Multiverse-Inventories' expected order [helmet, chestplate, leggings, boots]
-            newArmor[3] = closedInventory.getItem(36); // Helmet
-            newArmor[2] = closedInventory.getItem(37); // Chestplate
-            newArmor[1] = closedInventory.getItem(38); // Leggings
-            newArmor[0] = closedInventory.getItem(39); // Boots
-            ItemStack newOffHand = closedInventory.getItem(40);
-
-            // Before saving, ensure any filler items are removed from the actual data
-            for (int i = 0; i < newArmor.length; i++) {
-                if (newArmor[i] != null && inventoryGUIHelper.isFillerItem(newArmor[i])) {
-                    newArmor[i] = null; // Replace filler with null for saving
-                }
-            }
-            if (newOffHand != null && inventoryGUIHelper.isFillerItem(newOffHand)) {
-                newOffHand = null; // Replace filler with null for saving
-            }
-
-            // Delegate saving to InventoryDataProvider
-            inventoryDataProvider.savePlayerInventoryData(
-                    targetPlayer,
-                    worldName,
-                    profileType,
-                    newContents,
-                    newArmor,
-                    newOffHand
-            ).exceptionally(throwable -> {
-                // Error logging is now handled within InventoryDataProvider, but we can add a general one here too
-                Logging.severe("Error during inventory save process for " + targetPlayer.getName() + ": " + throwable.getMessage());
-                throwable.printStackTrace();
-                return null;
-            });
+        if (!(event.getInventory().getHolder() instanceof ModifiableInventoryHolder holder)) {
+            return;
         }
+
+        final OfflinePlayer targetPlayer = holder.getTargetPlayer();
+        final String worldName = holder.getWorldName();
+        final ProfileType profileType = holder.getProfileType();
+        final Inventory closedInventory = event.getInventory();
+
+        // Extract contents: 0-35 for inventory, 36-39 for armor, 40 for off-hand
+        ItemStack[] newContents = Arrays.copyOfRange(closedInventory.getContents(), 0, 36);
+        ItemStack[] newArmor = new ItemStack[4];
+        // Map GUI armor slots back to Multiverse-Inventories' expected order [helmet, chestplate, leggings, boots]
+        newArmor[3] = closedInventory.getItem(36); // Helmet
+        newArmor[2] = closedInventory.getItem(37); // Chestplate
+        newArmor[1] = closedInventory.getItem(38); // Leggings
+        newArmor[0] = closedInventory.getItem(39); // Boots
+        ItemStack newOffHand = closedInventory.getItem(40);
+
+        // Before saving, ensure any filler items are removed from the actual data
+        for (int i = 0; i < newArmor.length; i++) {
+            if (newArmor[i] != null && inventoryGUIHelper.isFillerItem(newArmor[i])) {
+                newArmor[i] = null; // Replace filler with null for saving
+            }
+        }
+        if (newOffHand != null && inventoryGUIHelper.isFillerItem(newOffHand)) {
+            newOffHand = null; // Replace filler with null for saving
+        }
+
+        // Delegate saving to InventoryDataProvider
+        inventoryDataProvider.savePlayerInventoryData(
+                targetPlayer,
+                worldName,
+                profileType,
+                newContents,
+                newArmor,
+                newOffHand
+        ).exceptionally(throwable -> {
+            // Error logging is now handled within InventoryDataProvider, but we can add a general one here too
+            Logging.severe("Error during inventory save process for " + targetPlayer.getName() + ": " + throwable.getMessage());
+            throwable.printStackTrace();
+            return null;
+        });
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -85,30 +85,12 @@ final class InventoryViewListener implements MVInvListener {
                 if (cursorItem != null && cursorItem.getType() != Material.AIR && inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
                     event.setCancelled(true); // Take full control of the event
 
-                    // If there was a filler in the slot, it needs to be put back after the new item is placed.
-                    // If there was a valid item, it goes to the cursor.
-                    ItemStack itemToReturnToCursor = currentItem; // This could be the filler or a valid item
-
                     // Place the new item from cursor into the clicked slot
                     event.getInventory().setItem(clickedSlot, cursorItem);
 
                     // Clear the player's cursor
                     player.setItemOnCursor(null);
 
-                    // If the item that was in the slot (itemToReturnToCursor) was a filler,
-                    // we don't want it to go anywhere. It should effectively be "discarded" from the event.
-                    // If it was a valid item, it should go to the player's cursor.
-                    if (itemToReturnToCursor != null && !inventoryGUIHelper.isFillerItem(itemToReturnToCursor)) {
-                        player.setItemOnCursor(itemToReturnToCursor);
-                    } else if (itemToReturnToCursor != null && inventoryGUIHelper.isFillerItem(itemToReturnToCursor)) {
-                        // If it was a filler, ensure the slot gets a fresh filler if it becomes empty
-                        // (though we just put cursorItem there, this is a safeguard)
-                        Bukkit.getScheduler().runTaskLater(inventories, () -> {
-                            if (event.getInventory().getItem(clickedSlot) == null || event.getInventory().getItem(clickedSlot).getType() == Material.AIR) {
-                                event.getInventory().setItem(clickedSlot, inventoryGUIHelper.createFillerItemForSlot(clickedSlot));
-                            }
-                        }, 1L);
-                    }
                     player.updateInventory(); // Update client to reflect changes
                     return; // Event handled
                 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -46,7 +46,7 @@ final class InventoryViewListener implements MVInvListener {
     // This listener will cancel any clicks or drags in inventories that have the ReadOnlyInventoryHolder marker.
     @EventMethod
     @DefaultEventPriority(EventPriority.NORMAL)
-    public void onInventoryClick(InventoryClickEvent event) {
+    void onInventoryClick(InventoryClickEvent event) {
         // If it's a read-only inventory, cancel all clicks.
         if (event.getInventory().getHolder() instanceof ReadOnlyInventoryHolder ||
                 (event.getClickedInventory() != null && event.getClickedInventory().getHolder() instanceof ReadOnlyInventoryHolder)) {
@@ -127,7 +127,7 @@ final class InventoryViewListener implements MVInvListener {
     // Also cancel drag events to prevent items from being dragged into/out of the inventory
     @EventMethod
     @DefaultEventPriority(EventPriority.NORMAL)
-    public void onInventoryDrag(InventoryDragEvent event) {
+    void onInventoryDrag(InventoryDragEvent event) {
         // If it is a read-only inventory, cancel all drags
         if (event.getInventory().getHolder() instanceof ReadOnlyInventoryHolder) {
             event.setCancelled(true);
@@ -177,7 +177,7 @@ final class InventoryViewListener implements MVInvListener {
     // Event handler for InventoryCloseEvent to save changes
     @EventMethod
     @DefaultEventPriority(EventPriority.NORMAL)
-    public void onInventoryClose(InventoryCloseEvent event) {
+    void onInventoryClose(InventoryCloseEvent event) {
         // Check if the closed inventory has the custom ModifiableInventoryHolder class
         if (event.getInventory().getHolder() instanceof ModifiableInventoryHolder holder) {
             final OfflinePlayer targetPlayer = holder.getTargetPlayer();

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -116,7 +116,7 @@ final class InventoryViewListener implements MVInvListener {
                     Bukkit.getScheduler().runTaskLater(inventories, () -> {
                         // After Bukkit processes the click, if the slot is now empty, put the filler back.
                         if (event.getInventory().getItem(clickedSlot) == null || event.getInventory().getItem(clickedSlot).getType() == Material.AIR) {
-                            event.getInventory().setItem(clickedSlot, inventoryGUIHelper.createFillerItemForSlot(clickedSlot));
+                            event.getInventory().setItem(clickedSlot, inventoryGUIHelper.createFillerItemForSlot(clickedSlot, true));
                         }
                     }, 1L);
                 }
@@ -167,7 +167,7 @@ final class InventoryViewListener implements MVInvListener {
             Bukkit.getScheduler().runTaskLater(inventories, () -> {
                 for (int slot : event.getRawSlots()) {
                     if ((slot >= 36 && slot <= 40) && (event.getInventory().getItem(slot) == null || event.getInventory().getItem(slot).getType() == Material.AIR)) {
-                        event.getInventory().setItem(slot, inventoryGUIHelper.createFillerItemForSlot(slot)); // Use helper
+                        event.getInventory().setItem(slot, inventoryGUIHelper.createFillerItemForSlot(slot, true)); // Use helper
                     }
                 }
             }, 1L); // Run one tick later

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -1,0 +1,60 @@
+package org.mvplugins.multiverse.inventories.listeners;
+
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jvnet.hk2.annotations.Service;
+import org.mvplugins.multiverse.core.dynamiclistener.annotations.DefaultEventPriority;
+import org.mvplugins.multiverse.core.dynamiclistener.annotations.EventMethod;
+import org.mvplugins.multiverse.external.jakarta.inject.Inject;
+import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+
+@Service
+public final class InventoryViewListener implements MVInvListener {
+
+    private final MultiverseInventories inventories;
+
+    @Inject
+    InventoryViewListener(
+            @NotNull MultiverseInventories inventories) {
+        this.inventories = inventories;
+    }
+
+    // This class acts as a marker. When an inventory is created with this holder,
+    // the event listener can identify it as a read-only inventory.
+    public static class ReadOnlyInventoryHolder implements InventoryHolder {
+        @Override
+        public @NotNull Inventory getInventory() {
+            // This method is required by the interface but isn't strictly used for our marker purpose.
+            // The actual inventory is obtained from the InventoryClickEvent itself.
+            return null;
+        }
+    }
+    // This listener will cancel any clicks or drags in inventories that have the ReadOnlyInventoryHolder marker.
+    @EventMethod
+    @DefaultEventPriority(EventPriority.NORMAL)
+    public void onInventoryClick(InventoryClickEvent event) {
+        // Check if the inventory being clicked has the custom holder
+        if (event.getInventory().getHolder() instanceof ReadOnlyInventoryHolder) {
+            event.setCancelled(true);
+        }
+        // This covers cases where a player might click in their own inventory
+        // but the action is intended to move an item into the read-only inventory (e.g., shift-click).
+        else if (event.getClickedInventory() != null && event.getClickedInventory().getHolder() instanceof ReadOnlyInventoryHolder) {
+            event.setCancelled(true);
+        }
+    }
+
+    // Also cancel drag events to prevent items from being dragged into/out of the inventory
+    @EventMethod
+    @DefaultEventPriority(EventPriority.NORMAL)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (event.getInventory().getHolder() instanceof ReadOnlyInventoryHolder) {
+            event.setCancelled(true);
+        }
+    }
+}
+

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -1,5 +1,6 @@
 package org.mvplugins.multiverse.inventories.listeners;
 
+import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -215,7 +216,7 @@ final class InventoryViewListener implements MVInvListener {
                     newOffHand
             ).exceptionally(throwable -> {
                 // Error logging is now handled within InventoryDataProvider, but we can add a general one here too
-                inventories.getLogger().severe("Error during inventory save process for " + targetPlayer.getName() + ": " + throwable.getMessage());
+                Logging.severe("Error during inventory save process for " + targetPlayer.getName() + ": " + throwable.getMessage());
                 throwable.printStackTrace();
                 return null;
             });

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -59,10 +59,20 @@ final class InventoryViewListener implements MVInvListener {
             int clickedSlot = event.getRawSlot();
             ItemStack cursorItem = event.getCursor(); // Item held by the cursor
             ItemStack currentItem = event.getCurrentItem(); // Item in the clicked slot
+            Inventory customGUI = event.getInventory(); // The custom inventory
             Player player = (Player) event.getWhoClicked(); // The player who clicked
 
             // Define the special slots
-            boolean isSpecialSlot = (clickedSlot >= 36 && clickedSlot <= 40); // Armor (36-39) and Off-hand (40)
+            boolean isSpecialSlot =  (clickedSlot >= 36 && clickedSlot <= 40); // Armor (36-39) and Off-hand (40)
+
+            // Determine if the slot is one of the padding slots (41-44)
+            boolean isPaddingSlot =  (clickedSlot >= 41 && clickedSlot <= 44);
+
+            if (isPaddingSlot) {
+                // Clicks on padding slots are always cancelled and do nothing else.
+                event.setCancelled(true);
+                return;
+            }
 
             // --- Logic for special slots (armor/off-hand) ---
             if (isSpecialSlot) {
@@ -134,6 +144,15 @@ final class InventoryViewListener implements MVInvListener {
             for (int slot : event.getRawSlots()) {
                 // Define the special slots
                 boolean isSpecialSlot = (slot >= 36 && slot <= 40);
+
+                // Determine if the slot is one of the padding slots (41-44)
+                boolean isPaddingSlot = (slot >= 41 && slot <= 44);
+
+                if (isPaddingSlot) {
+                    // Clicks on padding slots are always cancelled and do nothing else.
+                    event.setCancelled(true);
+                    return;
+                }
 
                 if (isSpecialSlot) {
                     // Check if the dragged item is valid for this special slot

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -1,14 +1,11 @@
 package org.mvplugins.multiverse.inventories.listeners;
 
-import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.dynamiclistener.annotations.DefaultEventPriority;
@@ -16,16 +13,12 @@ import org.mvplugins.multiverse.core.dynamiclistener.annotations.EventMethod;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
-import org.mvplugins.multiverse.inventories.handleshare.SingleShareWriter;
-import org.mvplugins.multiverse.inventories.listeners.MVInvListener;
 import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
-import org.mvplugins.multiverse.inventories.share.Sharables;
 import org.mvplugins.multiverse.inventories.view.ModifiableInventoryHolder;
 import org.mvplugins.multiverse.inventories.view.ReadOnlyInventoryHolder;
 
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
 
 @Service
 final class InventoryViewListener implements MVInvListener {
@@ -41,6 +34,7 @@ final class InventoryViewListener implements MVInvListener {
         this.inventories = inventories;
         this.inventoryDataProvider = inventoryDataProvider;
     }
+
     // This listener will cancel any clicks or drags in inventories that have the ReadOnlyInventoryHolder marker.
     @EventMethod
     @DefaultEventPriority(EventPriority.NORMAL)
@@ -73,7 +67,6 @@ final class InventoryViewListener implements MVInvListener {
             final OfflinePlayer targetPlayer = holder.getTargetPlayer();
             final String worldName = holder.getWorldName();
             final ProfileType profileType = holder.getProfileType();
-            final MultiverseInventories plugin = holder.getInventories();
             final Inventory closedInventory = event.getInventory();
 
             // Extract contents: 0-35 for inventory, 36-39 for armor, 40 for off-hand
@@ -100,6 +93,6 @@ final class InventoryViewListener implements MVInvListener {
                 throwable.printStackTrace();
                 return null;
             });
-            }
         }
     }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -60,7 +60,6 @@ final class InventoryViewListener implements MVInvListener {
             int clickedSlot = event.getRawSlot();
             ItemStack cursorItem = event.getCursor(); // Item held by the cursor
             ItemStack currentItem = event.getCurrentItem(); // Item in the clicked slot
-            Inventory customGUI = event.getInventory(); // The custom inventory
             Player player = (Player) event.getWhoClicked(); // The player who clicked
 
             // Define the special slots
@@ -96,11 +95,17 @@ final class InventoryViewListener implements MVInvListener {
                 if (cursorItem != null && cursorItem.getType() != Material.AIR && inventoryGUIHelper.isValidItemForSlot(cursorItem, clickedSlot)) {
                     event.setCancelled(true); // Take full control of the event
 
-                    // Place the new item from cursor into the clicked slot
+                    // Place the new item from the cursor into the clicked slot
                     event.getInventory().setItem(clickedSlot, cursorItem);
 
-                    // Clear the player's cursor
-                    player.setItemOnCursor(null);
+                    // If the player tries to replace an item in the filler slot, check if the item is valid.
+                    if (currentItem != null && currentItem.getType() != Material.AIR && !inventoryGUIHelper.isFillerItem(currentItem)) {
+                        // If the original item was a real, non-filler item, put it on the player's cursor.
+                        player.setItemOnCursor(currentItem);
+                    } else {
+                        // If the original item was null, air, or a filler, clear the player's cursor.
+                        player.setItemOnCursor(null);
+                    }
 
                     player.updateInventory(); // Update client to reflect changes
                     return; // Event handled

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -18,7 +18,7 @@ import org.mvplugins.multiverse.core.dynamiclistener.annotations.EventMethod;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
-import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
+import org.mvplugins.multiverse.inventories.view.InventoryDataProvider;
 import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
 import org.mvplugins.multiverse.inventories.view.InventoryGUIHelper;
 import org.mvplugins.multiverse.inventories.view.ModifiableInventoryHolder;

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/InventoryViewListener.java
@@ -1,16 +1,27 @@
 package org.mvplugins.multiverse.inventories.listeners;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.core.dynamiclistener.annotations.DefaultEventPriority;
 import org.mvplugins.multiverse.core.dynamiclistener.annotations.EventMethod;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.handleshare.SingleShareWriter;
+import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
+import org.mvplugins.multiverse.inventories.share.Sharables;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 public final class InventoryViewListener implements MVInvListener {
@@ -33,6 +44,7 @@ public final class InventoryViewListener implements MVInvListener {
             return null;
         }
     }
+
     // This listener will cancel any clicks or drags in inventories that have the ReadOnlyInventoryHolder marker.
     @EventMethod
     @DefaultEventPriority(EventPriority.NORMAL)
@@ -56,5 +68,108 @@ public final class InventoryViewListener implements MVInvListener {
             event.setCancelled(true);
         }
     }
-}
 
+    // This holder stores context needed to save the inventory when it's closed.
+    public static class ModifiableInventoryHolder implements InventoryHolder {
+        private final OfflinePlayer targetPlayer;
+        private final String worldName;
+        private final ProfileType profileType;
+        private final MultiverseInventories inventories;
+
+        public ModifiableInventoryHolder(@NotNull OfflinePlayer targetPlayer,
+                                         @NotNull String worldName,
+                                         @NotNull ProfileType profileType,
+                                         @NotNull MultiverseInventories inventories) {
+            this.targetPlayer = targetPlayer;
+            this.worldName = worldName;
+            this.profileType = profileType;
+            this.inventories = inventories;
+        }
+
+        public @NotNull OfflinePlayer getTargetPlayer() {
+            return targetPlayer;
+        }
+
+        public @NotNull String getWorldName() {
+            return worldName;
+        }
+
+        public @NotNull ProfileType getProfileType() {
+            return profileType;
+        }
+
+        public @NotNull MultiverseInventories getInventories() {
+            return inventories;
+        }
+
+        @Override
+        public @NotNull Inventory getInventory() {
+            return null; // The actual inventory is passed via the event
+        }
+    }
+
+    // Event handler for InventoryCloseEvent to save changes
+    @EventMethod
+    @DefaultEventPriority(EventPriority.NORMAL)
+    public void onInventoryClose(InventoryCloseEvent event) {
+        // Check if the closed inventory has the custom ModifiableInventoryHolder class
+        if (event.getInventory().getHolder() instanceof ModifiableInventoryHolder holder) {
+            final OfflinePlayer targetPlayer = holder.getTargetPlayer();
+            final String worldName = holder.getWorldName();
+            final ProfileType profileType = holder.getProfileType();
+            final MultiverseInventories plugin = holder.getInventories();
+            final Inventory closedInventory = event.getInventory();
+
+            // Extract contents: 0-35 for inventory, 36-39 for armor, 40 for off-hand
+            ItemStack[] newContents = Arrays.copyOfRange(closedInventory.getContents(), 0, 36);
+            ItemStack[] newArmor = new ItemStack[4];
+            // Map GUI armor slots back to Multiverse-Inventories' expected order [helmet, chestplate, leggings, boots]
+            newArmor[0] = closedInventory.getItem(39); // Helmet
+            newArmor[1] = closedInventory.getItem(38); // Chestplate
+            newArmor[2] = closedInventory.getItem(37); // Leggings
+            newArmor[3] = closedInventory.getItem(36); // Boots
+            ItemStack newOffHand = closedInventory.getItem(40);
+
+            // Save the updated inventory, armor, and off-hand contents asynchronously
+            CompletableFuture<Void> saveFuture = CompletableFuture.allOf(
+                    SingleShareWriter.of(plugin, targetPlayer, worldName, profileType, Sharables.INVENTORY)
+                            .write(newContents, true) // true to update if player is online
+                            .thenRun(() -> plugin.getLogger().fine("Saved inventory for " + targetPlayer.getName() + " in " + worldName)),
+                    SingleShareWriter.of(plugin, targetPlayer, worldName, profileType, Sharables.ARMOR)
+                            .write(newArmor, true)
+                            .thenRun(() -> plugin.getLogger().fine("Saved armor for " + targetPlayer.getName() + " in " + worldName)),
+                    SingleShareWriter.of(plugin, targetPlayer, worldName, profileType, Sharables.OFF_HAND)
+                            .write(newOffHand, true)
+                            .thenRun(() -> plugin.getLogger().fine("Saved off-hand for " + targetPlayer.getName() + " in " + worldName))
+            );
+
+            saveFuture.thenRun(() -> {
+                plugin.getLogger().info("Inventory for player " + targetPlayer.getName() + " in world " + worldName + " has been modified and saved.");
+            }).exceptionally(throwable -> {
+                plugin.getLogger().severe("Failed to save inventory for " + targetPlayer.getName() + " in world " + worldName + ": " + throwable.getMessage());
+                throwable.printStackTrace();
+                return null;
+            });
+
+            // If the target player is online, update their live inventory
+            if (targetPlayer.isOnline()) {
+                Player onlinePlayer = targetPlayer.getPlayer();
+                if (onlinePlayer != null) {
+                    // Check if the online player is in the world whose inventory was modified
+                    // This is important to avoid overwriting their current inventory if they are in a different world
+                    if (onlinePlayer.getWorld().getName().equalsIgnoreCase(worldName)) {
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            onlinePlayer.getInventory().setContents(newContents);
+                            onlinePlayer.getInventory().setArmorContents(newArmor);
+                            onlinePlayer.getInventory().setItemInOffHand(newOffHand);
+                            onlinePlayer.updateInventory(); // Ensure client sees changes
+                            plugin.getLogger().info("Updated live inventory for online player " + onlinePlayer.getName() + " in world " + worldName);
+                        });
+                    } else {
+                        plugin.getLogger().info("Player " + onlinePlayer.getName() + " is online but in a different world (" + onlinePlayer.getWorld().getName() + "), not updating live inventory.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/MVInvListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/MVInvListener.java
@@ -2,6 +2,7 @@ package org.mvplugins.multiverse.inventories.listeners;
 
 import org.jvnet.hk2.annotations.Contract;
 import org.mvplugins.multiverse.core.dynamiclistener.DynamicListener;
+import org.mvplugins.multiverse.inventories.view.ReadOnlyInventoryHolder;
 
 @Contract
 public sealed interface MVInvListener extends DynamicListener permits InventoryViewListener, MVEventsListener, RespawnListener, ShareHandleListener, SpawnChangeListener {

--- a/src/main/java/org/mvplugins/multiverse/inventories/listeners/MVInvListener.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/listeners/MVInvListener.java
@@ -4,5 +4,5 @@ import org.jvnet.hk2.annotations.Contract;
 import org.mvplugins.multiverse.core.dynamiclistener.DynamicListener;
 
 @Contract
-public sealed interface MVInvListener extends DynamicListener permits MVEventsListener, RespawnListener, ShareHandleListener, SpawnChangeListener {
+public sealed interface MVInvListener extends DynamicListener permits InventoryViewListener, MVEventsListener, RespawnListener, ShareHandleListener, SpawnChangeListener {
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -1,5 +1,6 @@
 package org.mvplugins.multiverse.inventories.profile;
 
+import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -106,9 +107,9 @@ public final class InventoryDataProvider {
         }
         // If online but in a different world, or getPlayer() returned null, fall through to stored data logic
         if (onlineTarget != null) {
-            inventories.getLogger().fine("Player " + targetPlayer.getName() + " is online but in world " + onlineTarget.getWorld().getName() + ". Loading stored data for " + worldName + ".");
+            Logging.fine("Player " + targetPlayer.getName() + " is online but in world " + onlineTarget.getWorld().getName() + ". Loading stored data for " + worldName + ".");
         } else {
-            inventories.getLogger().warning("Player " + targetPlayer.getName() + " is online but getPlayer() returned null. Falling back to stored data.");
+            Logging.warning("Player " + targetPlayer.getName() + " is online but getPlayer() returned null. Falling back to stored data.");
         }
         // If the player is offline or online in a different world, or live data failed, load from Multiverse-Inventories' stored profiles
         return loadInventoryDataFromProfileStorage(targetPlayer, worldName);
@@ -215,10 +216,10 @@ public final class InventoryDataProvider {
         );
 
         return saveFuture.thenRun(() -> {
-            inventories.getLogger().info("Inventory for player " + targetPlayer.getName() + " in world " + worldName + " has been modified and saved.");
+            Logging.info("Inventory for player " + targetPlayer.getName() + " in world " + worldName + " has been modified and saved.");
             updateOnlinePlayerInventoryData(targetPlayer, worldName, newContents, newArmor, newOffHand);
         }).exceptionally(throwable -> {
-            inventories.getLogger().severe("Failed to save inventory for " + targetPlayer.getName() + " in world " + worldName + ": " + throwable.getMessage());
+            Logging.severe("Failed to save inventory for " + targetPlayer.getName() + " in world " + worldName + ": " + throwable.getMessage());
             throwable.printStackTrace();
             return null;
         });
@@ -244,7 +245,7 @@ public final class InventoryDataProvider {
         // Check if the online player is in the world whose inventory was modified
         // This is important to avoid overwriting their current inventory if they are in a different world
         if (!onlinePlayer.getWorld().getName().equalsIgnoreCase(worldName)) {
-            inventories.getLogger().info("Player " + onlinePlayer.getName() + " is online but in a different world (" + onlinePlayer.getWorld().getName() + "), not updating live inventory.");
+            Logging.info("Player " + onlinePlayer.getName() + " is online but in a different world (" + onlinePlayer.getWorld().getName() + "), not updating live inventory.");
             return;
         }
 
@@ -254,7 +255,7 @@ public final class InventoryDataProvider {
             onlinePlayer.getInventory().setArmorContents(newArmor);
             onlinePlayer.getInventory().setItemInOffHand(newOffHand);
             onlinePlayer.updateInventory(); // Ensure client sees changes
-            inventories.getLogger().info("Updated live inventory for online player " + onlinePlayer.getName() + " in world " + worldName);
+            Logging.info("Updated live inventory for online player " + onlinePlayer.getName() + " in world " + worldName);
         });
     }
 
@@ -270,13 +271,13 @@ public final class InventoryDataProvider {
         return CompletableFuture.allOf(
                 SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.INVENTORY)
                         .write(newContents, true) // true to update if player is online
-                        .thenRun(() -> inventories.getLogger().fine("Saved inventory for " + targetPlayer.getName() + " in " + worldName)),
+                        .thenRun(() -> Logging.fine("Saved inventory for " + targetPlayer.getName() + " in " + worldName)),
                 SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.ARMOR)
                         .write(newArmor, true)
-                        .thenRun(() -> inventories.getLogger().fine("Saved armor for " + targetPlayer.getName() + " in " + worldName)),
+                        .thenRun(() -> Logging.fine("Saved armor for " + targetPlayer.getName() + " in " + worldName)),
                 SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.OFF_HAND)
                         .write(newOffHand, true)
-                        .thenRun(() -> inventories.getLogger().fine("Saved off-hand for " + targetPlayer.getName() + " in " + worldName))
+                        .thenRun(() -> Logging.fine("Saved off-hand for " + targetPlayer.getName() + " in " + worldName))
         );
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -84,7 +84,7 @@ public final class InventoryDataProvider {
                         onlineTarget.getInventory().getContents(),
                         onlineTarget.getInventory().getArmorContents(),
                         onlineTarget.getInventory().getItemInOffHand(),
-                        "Displaying LIVE inventory for " + targetPlayer.getName() + worldName + ".",
+                        "Displaying LIVE inventory for " + targetPlayer.getName() + " in world " + worldName + ".",
                         profileType
                 ));
             }

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -4,6 +4,7 @@ import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
@@ -62,6 +63,7 @@ public final class InventoryDataProvider {
 
         // Non-inventory data
         public final double health;
+        public final double maxHealth;
         public final int level;
         public final float exp;
         public final int foodLevel;
@@ -76,6 +78,7 @@ public final class InventoryDataProvider {
          * @param status The status of the inventory data load (e.g., LIVE, STORED, NO_DATA_FOUND).
          * @param profileTypeUsed The profile type that was used to retrieve the data (e.g., SURVIVAL).
          * @param health The player's current health.
+         * @param maxHealth The player's maximum health.
          * @param level The player's current experience level.
          * @param exp The player's current experience progress towards the next level (0.0-1.0).
          * @param foodLevel The player's current food level (0-20).
@@ -86,7 +89,7 @@ public final class InventoryDataProvider {
          */
         @ApiStatus.AvailableSince("5.2")
         public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status,
-                                   ProfileType profileTypeUsed, double health, int level, float exp, int foodLevel,
+                                   ProfileType profileTypeUsed, double health, double maxHealth, int level, float exp, int foodLevel,
                                    float saturation, String lastLocation) {
             this.contents = contents;
             this.armor = armor;
@@ -96,6 +99,7 @@ public final class InventoryDataProvider {
 
             // Non-inventory data
             this.health = health;
+            this.maxHealth = maxHealth;
             this.level = level;
             this.exp = exp;
             this.foodLevel = foodLevel;
@@ -154,6 +158,7 @@ public final class InventoryDataProvider {
                 InventoryStatus.LIVE_INVENTORY,
                 profileType,
                 onlineTarget.getHealth(),
+                onlineTarget.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(),
                 onlineTarget.getLevel(),
                 onlineTarget.getExp(),
                 onlineTarget.getFoodLevel(),
@@ -189,6 +194,8 @@ public final class InventoryDataProvider {
 
                 // Non-inventory data
                 double storedHealth = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.HEALTH)
+                        .read().join();
+                double storedMaxHealth = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.MAX_HEALTH)
                         .read().join();
                 int storedLevel = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.LEVEL)
                         .read().join();
@@ -227,6 +234,7 @@ public final class InventoryDataProvider {
                         InventoryStatus.STORED_INVENTORY,
                         profileTypeToUse,
                         storedHealth,
+                        storedMaxHealth,
                         storedLevel,
                         storedExp,
                         storedFoodLevel,

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
@@ -25,7 +26,10 @@ import java.util.concurrent.CompletionException; // Needed for async error handl
 /**
  * Provides methods for asynchronously loading player inventory data.
  * This class encapsulates the business logic for fetching inventory, armor, and off-hand contents.
+ *
+ * @since 5.2
  */
+@ApiStatus.AvailableSince("5.2")
 @Service
 public final class InventoryDataProvider {
 
@@ -43,7 +47,10 @@ public final class InventoryDataProvider {
 
     /**
      * Represents the loaded inventory data.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public static class PlayerInventoryData {
         public final ItemStack[] contents;
         public final ItemStack[] armor;
@@ -51,6 +58,17 @@ public final class InventoryDataProvider {
         public final String statusMessage; // To indicate if it's live or stored data
         public final ProfileType profileTypeUsed; // To pass back which profile type was used for stored data
 
+        /**
+         *
+         * @param contents
+         * @param armor
+         * @param offHand
+         * @param statusMessage
+         * @param profileTypeUsed
+         *
+         * @since 5.2
+         */
+        @ApiStatus.AvailableSince("5.2")
         public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, String statusMessage, ProfileType profileTypeUsed) {
             this.contents = contents;
             this.armor = armor;
@@ -68,7 +86,10 @@ public final class InventoryDataProvider {
      * @param targetPlayer The OfflinePlayer whose inventory data to load.
      * @param worldName The name of the world to load the inventory from (either live or stored).
      * @return A CompletableFuture that will complete with PlayerInventoryData or an exception.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public CompletableFuture<PlayerInventoryData> loadPlayerInventoryData(
             @NotNull OfflinePlayer targetPlayer,
             @NotNull String worldName
@@ -135,7 +156,6 @@ public final class InventoryDataProvider {
             });
         }
 
-
     /**
      * Asynchronously saves a player's inventory data to their Multiverse-Inventories profile.
      * If the player is online and in the target world, their live inventory is also updated.
@@ -147,7 +167,10 @@ public final class InventoryDataProvider {
      * @param newArmor The new armor contents (helmet, chestplate, leggings, boots).
      * @param newOffHand The new off-hand item.
      * @return A CompletableFuture that completes when saving is done, or an exception occurs.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public CompletableFuture<Void> savePlayerInventoryData(
             @NotNull OfflinePlayer targetPlayer,
             @NotNull String worldName,

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -68,11 +68,16 @@ public final class InventoryDataProvider {
 
         /**
          *
-         * @param contents
-         * @param armor
-         * @param offHand
-         * @param status
-         * @param profileTypeUsed
+         * @param contents The player's main inventory contents (slots 0-35).
+         * @param armor The player's armor contents (boots, leggings, chestplate, helmet).
+         * @param offHand The player's off-hand item.
+         * @param status The status of the inventory data load (e.g., LIVE, STORED, NO_DATA_FOUND).
+         * @param profileTypeUsed The profile type that was used to retrieve the data (e.g., SURVIVAL).
+         * @param health The player's current health.
+         * @param level The player's current experience level.
+         * @param exp The player's current experience progress towards the next level (0.0-1.0).
+         * @param foodLevel The player's current food level (0-20).
+         * @param saturation The player's current saturation level.
          *
          * @since 5.2
          */

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -55,7 +55,7 @@ public final class InventoryDataProvider {
         public final ItemStack[] contents;
         public final ItemStack[] armor;
         public final ItemStack offHand;
-        public final String statusMessage; // To indicate if it's live or stored data
+        public final InventoryStatus status; // To indicate if it's live or stored data
         public final ProfileType profileTypeUsed; // To pass back which profile type was used for stored data
 
         /**
@@ -63,17 +63,17 @@ public final class InventoryDataProvider {
          * @param contents
          * @param armor
          * @param offHand
-         * @param statusMessage
+         * @param status
          * @param profileTypeUsed
          *
          * @since 5.2
          */
         @ApiStatus.AvailableSince("5.2")
-        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, String statusMessage, ProfileType profileTypeUsed) {
+        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status, ProfileType profileTypeUsed) {
             this.contents = contents;
             this.armor = armor;
             this.offHand = offHand;
-            this.statusMessage = statusMessage;
+            this.status = status;
             this.profileTypeUsed = profileTypeUsed;
         }
     }
@@ -125,7 +125,7 @@ public final class InventoryDataProvider {
                 onlineTarget.getInventory().getContents(),
                 onlineTarget.getInventory().getArmorContents(),
                 onlineTarget.getInventory().getItemInOffHand(),
-                "Displaying LIVE inventory for " + onlineTarget.getName() + " in world " + worldName + ".",
+                InventoryStatus.LIVE_INVENTORY,
                 profileType
         ));
     }
@@ -143,7 +143,7 @@ public final class InventoryDataProvider {
 
             PlayerProfile tempProfile = loadMVInvPlayerProfile(container, targetPlayer);
             if (tempProfile == null) {
-                throw new IllegalStateException("No player data found for " + targetPlayer.getName() + " in world " + worldName + ". Try checking a different world or ensure the player has played in this world.");
+                throw new IllegalStateException(InventoryStatus.NO_DATA_FOUND.getFormattedMessage(targetPlayer.getName(), worldName));
             }
             ProfileType profileTypeToUse = tempProfile.getProfileType();
             try {
@@ -155,7 +155,7 @@ public final class InventoryDataProvider {
                         contents,
                         armor,
                         offHand,
-                        "Displaying STORED inventory for " + targetPlayer.getName() + " in world " + worldName + ".",
+                        InventoryStatus.STORED_INVENTORY,
                         profileTypeToUse
                 );
             } catch (CompletionException e) {

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -23,8 +23,8 @@ import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
 import org.mvplugins.multiverse.inventories.profile.key.ProfileTypes;
 import org.mvplugins.multiverse.inventories.share.Sharables;
 
-import java.util.concurrent.CompletableFuture; // Needed for async operations
-import java.util.concurrent.CompletionException; // Needed for async error handling
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Provides methods for asynchronously loading player inventory data.
@@ -58,8 +58,8 @@ public final class InventoryDataProvider {
         public final ItemStack[] contents;
         public final ItemStack[] armor;
         public final ItemStack offHand;
-        public final InventoryStatus status; // To indicate if it's live or stored data
-        public final ProfileType profileTypeUsed; // To pass back which profile type was used for stored data
+        public final InventoryStatus status;
+        public final ProfileType profileTypeUsed;
 
         // Non-inventory data
         public final double health;

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -59,6 +59,13 @@ public final class InventoryDataProvider {
         public final InventoryStatus status; // To indicate if it's live or stored data
         public final ProfileType profileTypeUsed; // To pass back which profile type was used for stored data
 
+        // Non-inventory data
+        public final double health;
+        public final int level;
+        public final float exp;
+        public final int foodLevel;
+        public final float saturation;
+
         /**
          *
          * @param contents
@@ -70,12 +77,23 @@ public final class InventoryDataProvider {
          * @since 5.2
          */
         @ApiStatus.AvailableSince("5.2")
-        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status, ProfileType profileTypeUsed) {
+        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status,
+                                   ProfileType profileTypeUsed, double health, int level, float exp, int foodLevel,
+                                   float saturation) {
             this.contents = contents;
             this.armor = armor;
             this.offHand = offHand;
             this.status = status;
             this.profileTypeUsed = profileTypeUsed;
+
+            // Non-inventory data
+            this.health = health;
+            this.level = level;
+            this.exp = exp;
+            this.foodLevel = foodLevel;
+            this.saturation = saturation;
+
+
         }
     }
 
@@ -127,7 +145,12 @@ public final class InventoryDataProvider {
                 onlineTarget.getInventory().getArmorContents(),
                 onlineTarget.getInventory().getItemInOffHand(),
                 InventoryStatus.LIVE_INVENTORY,
-                profileType
+                profileType,
+                onlineTarget.getHealth(),
+                onlineTarget.getLevel(),
+                onlineTarget.getExp(),
+                onlineTarget.getFoodLevel(),
+                onlineTarget.getSaturation()
         ));
     }
 
@@ -152,12 +175,29 @@ public final class InventoryDataProvider {
                 ItemStack[] armor = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.ARMOR).read().join();
                 ItemStack offHand = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.OFF_HAND).read().join();
 
+                // Non-inventory data
+                double storedHealth = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.HEALTH)
+                        .read().join();
+                int storedLevel = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.LEVEL)
+                        .read().join();
+                float storedExp = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.EXPERIENCE)
+                        .read().join();
+                int storedFoodLevel = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.FOOD_LEVEL)
+                        .read().join();
+                float storedSaturationLevel = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.SATURATION)
+                        .read().join();
+
                 return new PlayerInventoryData(
                         contents,
                         armor,
                         offHand,
                         InventoryStatus.STORED_INVENTORY,
-                        profileTypeToUse
+                        profileTypeToUse,
+                        storedHealth,
+                        storedLevel,
+                        storedExp,
+                        storedFoodLevel,
+                        storedSaturationLevel
                 );
             } catch (CompletionException e) {
                 // Unwrap CompletionException to get the actual cause

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.external.jetbrains.annotations.Nullable;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
 import org.mvplugins.multiverse.inventories.handleshare.SingleShareReader;
 import org.mvplugins.multiverse.inventories.handleshare.SingleShareWriter;
@@ -153,7 +154,7 @@ public final class InventoryDataProvider {
             @NotNull ProfileType profileType,
             @NotNull ItemStack[] newContents,
             @NotNull ItemStack[] newArmor,
-            @NotNull ItemStack newOffHand
+            @Nullable ItemStack newOffHand
     ) {
         // Save the updated inventory, armor, and off-hand contents asynchronously
         CompletableFuture<Void> saveFuture = CompletableFuture.allOf(

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -2,6 +2,7 @@ package org.mvplugins.multiverse.inventories.profile;
 
 import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.attribute.Attribute;
@@ -67,12 +68,12 @@ public final class InventoryDataProvider {
         public final ProfileType profileTypeUsed;
 
         // Non-inventory data
-        public final double health;
-        public final double maxHealth;
-        public final int level;
-        public final float exp;
-        public final int foodLevel;
-        public final float saturation;
+        public final Double health;
+        public final Double maxHealth;
+        public final Integer level;
+        public final Float exp;
+        public final Integer foodLevel;
+        public final Float saturation;
         public final String lastLocation;
 
         /**
@@ -94,8 +95,8 @@ public final class InventoryDataProvider {
          */
         @ApiStatus.AvailableSince("5.2")
         public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status,
-                                   ProfileType profileTypeUsed, double health, double maxHealth, int level, float exp, int foodLevel,
-                                   float saturation, String lastLocation) {
+                                   ProfileType profileTypeUsed, Double health, Double maxHealth, Integer level, Float exp, Integer foodLevel,
+                                   Float saturation, String lastLocation) {
             this.contents = contents;
             this.armor = armor;
             this.offHand = offHand;
@@ -198,17 +199,17 @@ public final class InventoryDataProvider {
                 ItemStack offHand = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.OFF_HAND).read().join();
 
                 // Non-inventory data
-                double storedHealth = getSharableValue(Sharables.HEALTH, targetPlayer, worldName, profileTypeToUse, 20.0);
-                double storedMaxHealth = getSharableValue(Sharables.MAX_HEALTH, targetPlayer, worldName, profileTypeToUse, 20.0);
-                int storedLevel = getSharableValue(Sharables.LEVEL, targetPlayer, worldName, profileTypeToUse, 0);
-                float storedExp = getSharableValue(Sharables.EXPERIENCE, targetPlayer, worldName, profileTypeToUse, 0.0f);
-                int storedFoodLevel = getSharableValue(Sharables.FOOD_LEVEL, targetPlayer, worldName, profileTypeToUse, 20);
-                float storedSaturationLevel = getSharableValue(Sharables.SATURATION, targetPlayer, worldName, profileTypeToUse, 5.0f);
+                Double storedHealth = getSharableValue(Sharables.HEALTH, targetPlayer, worldName, profileTypeToUse);
+                Double storedMaxHealth = getSharableValue(Sharables.MAX_HEALTH, targetPlayer, worldName, profileTypeToUse);
+                Integer storedLevel = getSharableValue(Sharables.LEVEL, targetPlayer, worldName, profileTypeToUse);
+                Float storedExp = getSharableValue(Sharables.EXPERIENCE, targetPlayer, worldName, profileTypeToUse);
+                Integer storedFoodLevel = getSharableValue(Sharables.FOOD_LEVEL, targetPlayer, worldName, profileTypeToUse);
+                Float storedSaturationLevel = getSharableValue(Sharables.SATURATION, targetPlayer, worldName, profileTypeToUse);
                 String storedLastLocation;
 
                 // Check if LAST_LOCATION is enabled in config
                 if (!inventoriesConfig.getActiveOptionalShares().contains(Sharables.LAST_LOCATION)) {
-                    storedLastLocation = "Disabled in config";
+                    storedLastLocation = ChatColor.RED + "Disabled in Config";
                 } else { // if the location is null or the world is null
                     Location storedLocationObject = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.LAST_LOCATION).read().join();
                     if (storedLocationObject == null || storedLocationObject.getWorld() == null) {
@@ -265,21 +266,19 @@ public final class InventoryDataProvider {
      * @param targetPlayer The OfflinePlayer.
      * @param worldName The world name.
      * @param profileType The profile type.
-     * @param defaultValue The default value to return if sharable is disabled or data is null.
      * @param <T> The type of the sharable value.
      * @return The sharable value or the default value.
      */
     private <T> T getSharableValue(@NotNull Sharable<T> sharable,
                                             @NotNull OfflinePlayer targetPlayer,
                                             @NotNull String worldName,
-                                            @NotNull ProfileType profileType,
-                                            @NotNull T defaultValue) {
+                                            @NotNull ProfileType profileType) {
         try {
             T value = SingleShareReader.of(inventories, targetPlayer, worldName, profileType, sharable).read().join();
-            return value != null ? value : defaultValue;
+            return value;
         } catch (CompletionException e) {
             Logging.warning("Failed to read sharable '" + sharable.getNames()[0] + "' for player " + targetPlayer.getName() + " in world " + worldName + ": " + e.getCause().getMessage());
-            return defaultValue;
+            return null;
         }
     }
 

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -37,7 +37,7 @@ public final class InventoryDataProvider {
     private final MultiverseInventories inventories;
 
     @Inject
-    public InventoryDataProvider(
+    InventoryDataProvider(
             @NotNull ProfileContainerStoreProvider profileContainerStoreProvider,
             @NotNull MultiverseInventories inventories
     ) {

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryDataProvider.java
@@ -1,0 +1,200 @@
+package org.mvplugins.multiverse.inventories.profile;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jvnet.hk2.annotations.Service;
+import org.mvplugins.multiverse.external.jakarta.inject.Inject;
+import org.mvplugins.multiverse.external.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.handleshare.SingleShareReader;
+import org.mvplugins.multiverse.inventories.handleshare.SingleShareWriter;
+import org.mvplugins.multiverse.inventories.profile.container.ProfileContainer;
+import org.mvplugins.multiverse.inventories.profile.container.ProfileContainerStoreProvider;
+import org.mvplugins.multiverse.inventories.profile.data.PlayerProfile;
+import org.mvplugins.multiverse.inventories.profile.key.ContainerType;
+import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
+import org.mvplugins.multiverse.inventories.profile.key.ProfileTypes;
+import org.mvplugins.multiverse.inventories.share.Sharables;
+
+import java.util.concurrent.CompletableFuture; // Needed for async operations
+import java.util.concurrent.CompletionException; // Needed for async error handling
+
+/**
+ * Provides methods for asynchronously loading player inventory data.
+ * This class encapsulates the business logic for fetching inventory, armor, and off-hand contents.
+ */
+@Service
+public final class InventoryDataProvider {
+
+    private final ProfileContainerStoreProvider profileContainerStoreProvider;
+    private final MultiverseInventories inventories;
+
+    @Inject
+    public InventoryDataProvider(
+            @NotNull ProfileContainerStoreProvider profileContainerStoreProvider,
+            @NotNull MultiverseInventories inventories
+    ) {
+        this.profileContainerStoreProvider = profileContainerStoreProvider;
+        this.inventories = inventories;
+    }
+
+    /**
+     * Represents the loaded inventory data.
+     */
+    public static class PlayerInventoryData {
+        public final ItemStack[] contents;
+        public final ItemStack[] armor;
+        public final ItemStack offHand;
+        public final String statusMessage; // To indicate if it's live or stored data
+        public final ProfileType profileTypeUsed; // To pass back which profile type was used for stored data
+
+        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, String statusMessage, ProfileType profileTypeUsed) {
+            this.contents = contents;
+            this.armor = armor;
+            this.offHand = offHand;
+            this.statusMessage = statusMessage;
+            this.profileTypeUsed = profileTypeUsed;
+        }
+    }
+
+    /**
+     * Asynchronously loads a player's inventory data.
+     * If the player is online AND in the specified world, it attempts to get their live inventory.
+     * Otherwise (offline or online in a different world), it loads from Multiverse-Inventories' stored profiles.
+     *
+     * @param targetPlayer The OfflinePlayer whose inventory data to load.
+     * @param worldName The name of the world to load the inventory from (either live or stored).
+     * @return A CompletableFuture that will complete with PlayerInventoryData or an exception.
+     */
+    public CompletableFuture<PlayerInventoryData> loadPlayerInventoryData(
+            @NotNull OfflinePlayer targetPlayer,
+            @NotNull String worldName
+    ) {
+        // If the player is online, prioritize getting their live inventory
+        if (targetPlayer.isOnline()) {
+            Player onlineTarget = targetPlayer.getPlayer();
+            // Ensure onlineTarget is not null and their current world matches the requested worldName
+            if (onlineTarget != null && onlineTarget.getWorld().getName().equalsIgnoreCase(worldName)) {
+                // Get the actual ProfileType for the online player
+                ProfileType profileType = ProfileTypes.forPlayer(onlineTarget);
+                // Return immediately with live data
+                return CompletableFuture.completedFuture(new PlayerInventoryData(
+                        onlineTarget.getInventory().getContents(),
+                        onlineTarget.getInventory().getArmorContents(),
+                        onlineTarget.getInventory().getItemInOffHand(),
+                        "Displaying LIVE inventory for " + targetPlayer.getName() + worldName + ".",
+                        profileType
+                ));
+            }
+            // If online but in a different world, or getPlayer() returned null, fall through to stored data logic
+            if (onlineTarget != null) {
+                inventories.getLogger().fine("Player " + targetPlayer.getName() + " is online but in world " + onlineTarget.getWorld().getName() + ". Loading stored data for " + worldName + ".");
+            } else {
+                inventories.getLogger().warning("Player " + targetPlayer.getName() + " is online but getPlayer() returned null. Falling back to stored data.");
+            }
+        }
+            // If the player is offline or online in a different world, or live data failed, load from Multiverse-Inventories' stored profiles
+            return CompletableFuture.supplyAsync(() -> {
+                ProfileContainer container = profileContainerStoreProvider.getStore(ContainerType.WORLD)
+                        .getContainer(worldName);
+                if (container == null) {
+                    throw new IllegalStateException("Could not load profile container for world: " + worldName);
+                }
+
+                PlayerProfile tempProfile = container.getPlayerProfileNow(ProfileTypes.SURVIVAL, targetPlayer);
+                ProfileType profileTypeToUse = ProfileTypes.SURVIVAL;
+
+                if (tempProfile == null) {
+                    for (ProfileType type : ProfileTypes.getTypes()) {
+                        if (type.equals(ProfileTypes.SURVIVAL)) continue;
+                        tempProfile = container.getPlayerProfileNow(type, targetPlayer);
+                        if (tempProfile != null) {
+                            profileTypeToUse = type;
+                            break;
+                        }
+                    }
+                }
+
+                if (tempProfile == null) {
+                    throw new IllegalStateException("No player data found for " + targetPlayer.getName() + " in world " + worldName + ". Try checking a different world or ensure the player has played in this world.");
+                }
+
+                try {
+                    ItemStack[] contents = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.INVENTORY).read().join();
+                    ItemStack[] armor = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.ARMOR).read().join();
+                    ItemStack offHand = SingleShareReader.of(inventories, targetPlayer, worldName, profileTypeToUse, Sharables.OFF_HAND).read().join();
+
+                    return new PlayerInventoryData(contents, armor, offHand, "Displaying STORED inventory for " + targetPlayer.getName() + " in world " + worldName + ".", profileTypeToUse);
+                } catch (CompletionException e) {
+                    // Unwrap CompletionException to get the actual cause
+                    throw new IllegalStateException("Error loading inventory data: " + e.getCause().getMessage(), e.getCause());
+                }
+            });
+        }
+
+
+    /**
+     * Asynchronously saves a player's inventory data to their Multiverse-Inventories profile.
+     * If the player is online and in the target world, their live inventory is also updated.
+     *
+     * @param targetPlayer The OfflinePlayer whose inventory data to save.
+     * @param worldName The name of the world the inventory belongs to.
+     * @param profileType The ProfileType (e.g., SURVIVAL) associated with this inventory data.
+     * @param newContents The new main inventory contents (slots 0-35).
+     * @param newArmor The new armor contents (helmet, chestplate, leggings, boots).
+     * @param newOffHand The new off-hand item.
+     * @return A CompletableFuture that completes when saving is done, or an exception occurs.
+     */
+    public CompletableFuture<Void> savePlayerInventoryData(
+            @NotNull OfflinePlayer targetPlayer,
+            @NotNull String worldName,
+            @NotNull ProfileType profileType,
+            @NotNull ItemStack[] newContents,
+            @NotNull ItemStack[] newArmor,
+            @NotNull ItemStack newOffHand
+    ) {
+        // Save the updated inventory, armor, and off-hand contents asynchronously
+        CompletableFuture<Void> saveFuture = CompletableFuture.allOf(
+                SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.INVENTORY)
+                        .write(newContents, true) // true to update if player is online
+                        .thenRun(() -> inventories.getLogger().fine("Saved inventory for " + targetPlayer.getName() + " in " + worldName)),
+                SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.ARMOR)
+                        .write(newArmor, true)
+                        .thenRun(() -> inventories.getLogger().fine("Saved armor for " + targetPlayer.getName() + " in " + worldName)),
+                SingleShareWriter.of(inventories, targetPlayer, worldName, profileType, Sharables.OFF_HAND)
+                        .write(newOffHand, true)
+                        .thenRun(() -> inventories.getLogger().fine("Saved off-hand for " + targetPlayer.getName() + " in " + worldName))
+        );
+
+        return saveFuture.thenRun(() -> {
+            inventories.getLogger().info("Inventory for player " + targetPlayer.getName() + " in world " + worldName + " has been modified and saved.");
+
+            // If the target player is online, update their live inventory
+            if (targetPlayer.isOnline()) {
+                Player onlinePlayer = targetPlayer.getPlayer();
+                if (onlinePlayer != null) {
+                    // Check if the online player is in the world whose inventory was modified
+                    // This is important to avoid overwriting their current inventory if they are in a different world
+                    if (onlinePlayer.getWorld().getName().equalsIgnoreCase(worldName)) {
+                        // Run Bukkit API calls on the main thread
+                        Bukkit.getScheduler().runTask(inventories, () -> {
+                            onlinePlayer.getInventory().setContents(newContents);
+                            onlinePlayer.getInventory().setArmorContents(newArmor);
+                            onlinePlayer.getInventory().setItemInOffHand(newOffHand);
+                            onlinePlayer.updateInventory(); // Ensure client sees changes
+                            inventories.getLogger().info("Updated live inventory for online player " + onlinePlayer.getName() + " in world " + worldName);
+                        });
+                    } else {
+                        inventories.getLogger().info("Player " + onlinePlayer.getName() + " is online but in a different world (" + onlinePlayer.getWorld().getName() + "), not updating live inventory.");
+                    }
+                }
+            }
+        }).exceptionally(throwable -> {
+            inventories.getLogger().severe("Failed to save inventory for " + targetPlayer.getName() + " in world " + worldName + ": " + throwable.getMessage());
+            throwable.printStackTrace();
+            return null;
+        });
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryStatus.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/profile/InventoryStatus.java
@@ -1,0 +1,45 @@
+package org.mvplugins.multiverse.inventories.profile;
+
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents the status of an inventory data load operation.
+ * Provides a fixed set of states for clarity and type safety.
+ */
+public enum InventoryStatus {
+    /**
+     * Indicates that live inventory data from an online player was displayed.
+     */
+    LIVE_INVENTORY(ChatColor.GREEN + "Displaying LIVE inventory"),
+
+    /**
+     * Indicates that stored inventory data from Multiverse-Inventories profiles was displayed.
+     */
+    STORED_INVENTORY(ChatColor.GREEN + "Displaying STORED inventory"),
+
+    /**
+     * Indicates that no player data was found for the specified world/player.
+     */
+    NO_DATA_FOUND(ChatColor.RED + "No player data found");
+
+    private final String message;
+
+    InventoryStatus(@NotNull String message) {
+        this.message = message;
+    }
+
+    /**
+     * Gets the full status message including player and world context.
+     *
+     * @param playerName The name of the target player.
+     * @param worldName  The name of the target world.
+     * @return The formatted status message.
+     */
+    public @NotNull String getFormattedMessage(@NotNull String playerName, @NotNull String worldName) {
+        if (this == NO_DATA_FOUND) {
+            return this.message + " for " + playerName + " in world" + worldName + ". Try checking a different world or ensure the player has played in this world.";
+        }
+        return this.message + " for " + playerName + " in world " + worldName;
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryDataProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryDataProvider.java
@@ -1,4 +1,4 @@
-package org.mvplugins.multiverse.inventories.profile;
+package org.mvplugins.multiverse.inventories.view;
 
 import com.dumptruckman.minecraft.util.Logging;
 import org.bukkit.Bukkit;
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletionException;
  *
  * @since 5.2
  */
+@ApiStatus.Experimental
 @ApiStatus.AvailableSince("5.2")
 @Service
 public final class InventoryDataProvider {
@@ -52,66 +53,6 @@ public final class InventoryDataProvider {
         this.profileContainerStoreProvider = profileContainerStoreProvider;
         this.inventories = inventories;
         this.inventoriesConfig = inventoriesConfig;
-    }
-
-    /**
-     * Represents the loaded inventory data.
-     *
-     * @since 5.2
-     */
-    @ApiStatus.AvailableSince("5.2")
-    public static class PlayerInventoryData {
-        public final ItemStack[] contents;
-        public final ItemStack[] armor;
-        public final ItemStack offHand;
-        public final InventoryStatus status;
-        public final ProfileType profileTypeUsed;
-
-        // Non-inventory data
-        public final Double health;
-        public final Double maxHealth;
-        public final Integer level;
-        public final Float exp;
-        public final Integer foodLevel;
-        public final Float saturation;
-        public final String lastLocation;
-
-        /**
-         *
-         * @param contents The player's main inventory contents (slots 0-35).
-         * @param armor The player's armor contents (boots, leggings, chestplate, helmet).
-         * @param offHand The player's off-hand item.
-         * @param status The status of the inventory data load (e.g., LIVE, STORED, NO_DATA_FOUND).
-         * @param profileTypeUsed The profile type that was used to retrieve the data (e.g., SURVIVAL).
-         * @param health The player's current health.
-         * @param maxHealth The player's maximum health.
-         * @param level The player's current experience level.
-         * @param exp The player's current experience progress towards the next level (0.0-1.0).
-         * @param foodLevel The player's current food level (0-20).
-         * @param saturation The player's current saturation level.
-         * @param lastLocation The player's last location.
-         *
-         * @since 5.2
-         */
-        @ApiStatus.AvailableSince("5.2")
-        public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status,
-                                   ProfileType profileTypeUsed, Double health, Double maxHealth, Integer level, Float exp, Integer foodLevel,
-                                   Float saturation, String lastLocation) {
-            this.contents = contents;
-            this.armor = armor;
-            this.offHand = offHand;
-            this.status = status;
-            this.profileTypeUsed = profileTypeUsed;
-
-            // Non-inventory data
-            this.health = health;
-            this.maxHealth = maxHealth;
-            this.level = level;
-            this.exp = exp;
-            this.foodLevel = foodLevel;
-            this.saturation = saturation;
-            this.lastLocation = lastLocation;
-        }
     }
 
     /**

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -1,7 +1,6 @@
 package org.mvplugins.multiverse.inventories.view;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -48,8 +47,8 @@ public final class InventoryGUIHelper {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.displayName(Component.text(name, NamedTextColor.GOLD));
-            meta.lore(Collections.singletonList(Component.text(lore, NamedTextColor.GRAY)));
+            meta.setDisplayName(ChatColor.GOLD + name);
+            meta.setLore(Collections.singletonList(ChatColor.GRAY + lore));
             meta.getPersistentDataContainer().set(IS_FILLER_KEY, PersistentDataType.BYTE, (byte) 1); // store 1 for true
             item.setItemMeta(meta);
         }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -1,0 +1,112 @@
+package org.mvplugins.multiverse.inventories.view;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jvnet.hk2.annotations.Service; // Mark as a service for injection
+import org.mvplugins.multiverse.external.jakarta.inject.Inject;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+
+import java.util.Collections;
+
+/**
+ * A helper class for creating and validating items within the custom inventory GUIs.
+ * This centralizes logic for filler items and slot-specific item validation.
+ */
+@Service // Allows this class to be injected
+public final class InventoryGUIHelper { // Made public and final
+
+    private final NamespacedKey IS_FILLER_KEY; // Key to mark filler items
+
+    @Inject // Inject MultiverseInventories to create NamespacedKey
+    public InventoryGUIHelper(@NotNull MultiverseInventories inventories) {
+        this.IS_FILLER_KEY = new NamespacedKey(inventories, "is_mvinv_filler");
+    }
+    /**
+     * Creates a generic filler item for GUI slots.
+     * @param material The material of the filler item.
+     * @param name The display name of the item.
+     * @param lore The lore text for the item.
+     * @return The created ItemStack.
+     */
+    public ItemStack createFillerItem(Material material, String name, String lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.displayName(Component.text(name, NamedTextColor.GOLD));
+            meta.lore(Collections.singletonList(Component.text(lore, NamedTextColor.GRAY)));
+            meta.getPersistentDataContainer().set(IS_FILLER_KEY, PersistentDataType.BYTE, (byte) 1); // store 1 for true
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * Checks if a given ItemStack is a filler item created by this helper.
+     * @param item The ItemStack to check.
+     * @return True if the item is a filler, false otherwise.
+     */
+    public boolean isFillerItem(@NotNull ItemStack item) {
+        if (!item.hasItemMeta()) {
+            return false;
+        }
+        return item.getItemMeta().getPersistentDataContainer().has(IS_FILLER_KEY, PersistentDataType.BYTE) &&
+                item.getItemMeta().getPersistentDataContainer().get(IS_FILLER_KEY, PersistentDataType.BYTE) == (byte) 1;
+    }
+
+    /**
+     * Determines if an ItemStack is valid for a given special inventory slot in the custom GUI.
+     * This method is used for both armor and off-hand slot validation.
+     * @param item The ItemStack to check.
+     * @param slot The raw slot number (36-40 for armor/off-hand).
+     * @return True if the item is valid for the slot, false otherwise.
+     */
+    public boolean isValidItemForSlot(@NotNull ItemStack item, int slot) {
+        if (item.getType() == Material.AIR) {
+            return true; // Air is always valid (it means the slot is empty)
+        }
+        // If it's a filler item, it's considered valid for its own slot context (e.g., when checking if slot is empty)
+        if (isFillerItem(item)) {
+            return true;
+        }
+
+        switch (slot) {
+            case 39: // Helmet slot
+                return item.getType().name().endsWith("_HELMET");
+            case 38: // Chestplate slot
+                return item.getType().name().endsWith("_CHESTPLATE");
+            case 37: // Leggings slot
+                return item.getType().name().endsWith("_LEGGINGS");
+            case 36: // Boots slot
+                return item.getType().name().endsWith("_BOOTS");
+            case 40: // Off-hand slot
+                // Off-hand is very permissive in vanilla. Allow any non-air item.
+                // If you want to restrict this further (e.g., only shields/totems),
+                // add more specific Material checks here.
+                return true;
+            default:
+                return true; // For non-special slots (main inventory), any item is generally allowed.
+        }
+    }
+
+    /**
+     * Creates the appropriate filler item for a given special slot in the custom GUI.
+     * @param slot The raw slot number (36-40).
+     * @return The specific filler ItemStack for that slot.
+     */
+    public ItemStack createFillerItemForSlot(int slot) {
+        switch (slot) {
+            case 39: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
+            case 38: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
+            case 37: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
+            case 36: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
+            case 40: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
+            default: return new ItemStack(Material.AIR); // Should not happen for these slots
+        }
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
-import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 
 import java.util.List;
 import java.text.DecimalFormat;
@@ -27,6 +26,7 @@ import java.util.Collections;
  *
  * @since 5.2
  */
+@ApiStatus.Experimental
 @ApiStatus.AvailableSince("5.2")
 @Service
 public final class InventoryGUIHelper {
@@ -246,7 +246,7 @@ public final class InventoryGUIHelper {
      */
     @ApiStatus.AvailableSince("5.2")
     public void populateInventoryGUI(@NotNull Inventory inv,
-                                     @NotNull InventoryDataProvider.PlayerInventoryData playerInventoryData,
+                                     @NotNull PlayerInventoryData playerInventoryData,
                                      boolean isModifiable) {
         // Fill main inventory slots (0–35)
         if (playerInventoryData.contents != null) {

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -68,8 +69,9 @@ public final class InventoryGUIHelper {
         if (!item.hasItemMeta()) {
             return false;
         }
-        return item.getItemMeta().getPersistentDataContainer().has(IS_FILLER_KEY, PersistentDataType.BYTE) &&
-                item.getItemMeta().getPersistentDataContainer().get(IS_FILLER_KEY, PersistentDataType.BYTE) == (byte) 1;
+        PersistentDataContainer persistentDataContainer = item.getItemMeta().getPersistentDataContainer();
+        return persistentDataContainer.has(IS_FILLER_KEY, PersistentDataType.BYTE) &&
+                persistentDataContainer.getOrDefault(IS_FILLER_KEY, PersistentDataType.BYTE, (byte) 0) == (byte) 1;
     }
 
     /**
@@ -92,28 +94,24 @@ public final class InventoryGUIHelper {
             return true;
         }
 
-        switch (slot) {
-            case 36: // Helmet slot
-                return item.getType().name().endsWith("_HELMET");
-            case 37: // Chestplate slot
-                return item.getType().name().endsWith("_CHESTPLATE");
-            case 38: // Leggings slot
-                return item.getType().name().endsWith("_LEGGINGS");
-            case 39: // Boots slot
-                return item.getType().name().endsWith("_BOOTS");
-            case 40: // Off-hand slot
-                // Off-hand is very permissive in vanilla. Allow any non-air item.
-                // If you want to restrict this further (e.g., only shields/totems),
-                // add more specific Material checks here.
-                return true;
-            case 41: // Padding slot
-            case 42: // Padding slot
-            case 43: // Padding slot
-            case 44: // Padding slot
-                return false; // Cannot place items in padding slots
-            default:
-                return true; // For non-special slots (main inventory), any item is generally allowed.
-        }
+        return switch (slot) {
+            case 36 -> item.getType().name().endsWith("_HELMET");
+            case 37 -> item.getType().name().endsWith("_CHESTPLATE");
+            case 38 -> item.getType().name().endsWith("_LEGGINGS");
+            case 39 -> item.getType().name().endsWith("_BOOTS");
+
+            // Off-hand is very permissive in vanilla. Allow any non-air item.
+            // If you want to restrict this further (e.g., only shields/totems),
+            // add more specific Material checks here.
+            case 40 -> true;
+
+            // Padding slot
+            // Cannot place items in padding slots
+            case 41, 42, 43, 44 -> false;
+
+            // For non-special slots (main inventory), any item is generally allowed.
+            default -> true;
+        };
     }
 
     /**
@@ -126,17 +124,14 @@ public final class InventoryGUIHelper {
      */
     @ApiStatus.AvailableSince("5.2")
     public ItemStack createFillerItemForSlot(int slot) {
-        switch (slot) {
-            case 36: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
-            case 37: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
-            case 38: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
-            case 39: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
-            case 40: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
-            case 41:
-            case 42:
-            case 43:
-            case 44: return createFillerItem(Material.BARRIER, " ", " "); // Padding slots
-            default: return new ItemStack(Material.AIR); // Should not happen for these slots
-        }
+        return switch (slot) {
+            case 36 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
+            case 37 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
+            case 38 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
+            case 39 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
+            case 40 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
+            case 41, 42, 43, 44 -> createFillerItem(Material.BARRIER, " ", " "); // Padding slots
+            default -> new ItemStack(Material.AIR); // Should not happen for these slots
+        };
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -122,13 +122,19 @@ public final class InventoryGUIHelper {
      * @since 5.2
      */
     @ApiStatus.AvailableSince("5.2")
-    public ItemStack createFillerItemForSlot(int slot) {
+    public ItemStack createFillerItemForSlot(int slot, boolean isModifiable) {
+        String helmetLore = isModifiable ? "Place Helmet Here" : "No Helmet";
+        String chestplateLore = isModifiable ? "Place Chestplate Here" : "No Chestplate";
+        String leggingsLore = isModifiable ? "Place Leggings Here" : "No Leggings";
+        String bootsLore = isModifiable ? "Place Boots Here" : "No Boots";
+        String offHandLore = isModifiable ? "Place Off-Hand Item Here" : "No Off-Hand Item";
+
         return switch (slot) {
-            case 36 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
-            case 37 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
-            case 38 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
-            case 39 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
-            case 40 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
+            case 36 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", helmetLore);
+            case 37 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", chestplateLore);
+            case 38 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", leggingsLore);
+            case 39 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", bootsLore);
+            case 40 -> createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", offHandLore);
             case 41, 42, 43, 44 -> createFillerItem(Material.BARRIER, " ", " "); // Padding slots
             default -> new ItemStack(Material.AIR); // Should not happen for these slots
         };

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -202,6 +202,14 @@ public final class InventoryGUIHelper {
         return createDisplayItem(Material.COOKED_BEEF, "Food & Saturation", lore);
     }
 
+    private ItemStack createLastLocationDisplayItem(@NotNull String locationString) {
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.WHITE + "Last Location:");
+        // Split the location string if it's too long, or just add it directly
+        // Assuming locationString is already formatted like "world (x.x, y.y, z.z)"
+        lore.add(ChatColor.YELLOW + locationString);
+        return createDisplayItem(Material.COMPASS, "Last Location", lore);
+    }
     /**
      * Helper method to get an item for a slot, returning a filler if the item is null or air.
      * @param item The actual ItemStack from player data. Can be null.
@@ -257,9 +265,7 @@ public final class InventoryGUIHelper {
         inv.setItem(41, createHealthDisplayItem(playerInventoryData.health));
         inv.setItem(42, createFoodDisplayItem(playerInventoryData.foodLevel, playerInventoryData.saturation));
         inv.setItem(43, createLevelDisplayItem(playerInventoryData.level, playerInventoryData.exp));
-
-        // Slot 44 will be a generic filler/padding item
-        inv.setItem(44, createFillerItemForSlot(44, isModifiable));
+        inv.setItem(44, createLastLocationDisplayItem(playerInventoryData.lastLocation));
 
         /*// Fill the remaining slots (41-44) with non-interactable filler items
         for (int i = 41; i <= 44; i++) {

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -3,6 +3,7 @@ package org.mvplugins.multiverse.inventories.view;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -12,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.profile.InventoryDataProvider;
 
 import java.util.Collections;
 
@@ -138,5 +140,65 @@ public final class InventoryGUIHelper {
             case 41, 42, 43, 44 -> createFillerItem(Material.BARRIER, " ", " "); // Padding slots
             default -> new ItemStack(Material.AIR); // Should not happen for these slots
         };
+    }
+
+    /**
+     * Populates the given custom inventory GUI with player inventory data and appropriate filler items.
+     * @param inv The Inventory GUI to populate.
+     * @param playerInventoryData The data containing player's contents, armor, and off-hand.
+     * @param isModifiable True if the inventory is modifiable, false for read-only.
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
+    public void populateInventoryGUI(@NotNull Inventory inv,
+                                     @NotNull InventoryDataProvider.PlayerInventoryData playerInventoryData,
+                                     boolean isModifiable) {
+        // Fill main inventory slots (0–35)
+        if (playerInventoryData.contents != null) {
+            for (int i = 0; i < Math.min(playerInventoryData.contents.length, 36); i++) {
+                inv.setItem(i, playerInventoryData.contents[i]);
+            }
+        }
+        // Armor slot mapping for display in the GUI and add fillers if empty
+        // GUI Slots: 36=Helmet, 37=Chestplate, 38=Leggings, 39=Boots
+        // Minecraft Internal: armor[3]=Helmet, armor[2]=Chestplate, armor[1]=Leggings, armor[0]=Boots
+
+        // Slot 36: Helmet
+        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
+            inv.setItem(36, createFillerItemForSlot(36, isModifiable));
+        } else {
+            inv.setItem(36, playerInventoryData.armor[3]);
+        }
+        // Slot 37: Chestplate
+        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
+            inv.setItem(37, createFillerItemForSlot(37, isModifiable));
+        } else {
+            inv.setItem(37, playerInventoryData.armor[2]);
+        }
+        // Slot 38: Leggings
+        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
+            inv.setItem(38, createFillerItemForSlot(38, isModifiable));
+        } else {
+            inv.setItem(38, playerInventoryData.armor[1]);
+        }
+        // Slot 39: Boots
+        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
+            inv.setItem(39, createFillerItemForSlot(39, isModifiable));
+        } else {
+            inv.setItem(39, playerInventoryData.armor[0]);
+        }
+
+        // Off-hand slot (40) and add filler if empty
+        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
+            inv.setItem(40, createFillerItemForSlot(40, isModifiable));
+        } else {
+            inv.setItem(40, playerInventoryData.offHand);
+        }
+
+        // Fill the remaining slots (41-44) with non-interactable filler items
+        for (int i = 41; i <= 44; i++) {
+            inv.setItem(i, createFillerItemForSlot(i, isModifiable)); // Use createFillerItemForSlot for padding too
+        }
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -181,10 +181,10 @@ public final class InventoryGUIHelper {
         return item;
     }
 
-    private ItemStack createHealthDisplayItem(double health) {
+    private ItemStack createHealthDisplayItem(double health, double maxHealth) {
         List<String> lore = new ArrayList<>();
         DecimalFormat df = new DecimalFormat("0.0");
-        lore.add(ChatColor.WHITE + "Current: " + ChatColor.RED + df.format(health) + ChatColor.WHITE + " / " + ChatColor.RED + "20.0");
+        lore.add(ChatColor.WHITE + "Current: " + ChatColor.RED + df.format(health) + ChatColor.WHITE + " / " + ChatColor.RED + df.format(maxHealth));
         return createDisplayItem(Material.RED_DYE, "Health", lore);
     }
 
@@ -262,7 +262,7 @@ public final class InventoryGUIHelper {
         inv.setItem(40, getOrFillItem(playerInventoryData.offHand, 40, isModifiable));
 
         // These slots are always treated as read-only by the listener.
-        inv.setItem(41, createHealthDisplayItem(playerInventoryData.health));
+        inv.setItem(41, createHealthDisplayItem(playerInventoryData.health, playerInventoryData.maxHealth));
         inv.setItem(42, createFoodDisplayItem(playerInventoryData.foodLevel, playerInventoryData.saturation));
         inv.setItem(43, createLevelDisplayItem(playerInventoryData.level, playerInventoryData.exp));
         inv.setItem(44, createLastLocationDisplayItem(playerInventoryData.lastLocation));

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -27,8 +27,8 @@ public final class InventoryGUIHelper {
 
     private final NamespacedKey IS_FILLER_KEY; // Key to mark filler items
 
-    @Inject // Inject MultiverseInventories to create NamespacedKey
-    public InventoryGUIHelper(@NotNull MultiverseInventories inventories) {
+    @Inject
+    InventoryGUIHelper(@NotNull MultiverseInventories inventories) {
         this.IS_FILLER_KEY = new NamespacedKey(inventories, "is_mvinv_filler");
     }
 

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-import org.jvnet.hk2.annotations.Service; // Mark as a service for injection
+import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
 
@@ -18,8 +18,8 @@ import java.util.Collections;
  * A helper class for creating and validating items within the custom inventory GUIs.
  * This centralizes logic for filler items and slot-specific item validation.
  */
-@Service // Allows this class to be injected
-public final class InventoryGUIHelper { // Made public and final
+@Service
+public final class InventoryGUIHelper {
 
     private final NamespacedKey IS_FILLER_KEY; // Key to mark filler items
 
@@ -89,6 +89,11 @@ public final class InventoryGUIHelper { // Made public and final
                 // If you want to restrict this further (e.g., only shields/totems),
                 // add more specific Material checks here.
                 return true;
+            case 41: // Padding slot
+            case 42: // Padding slot
+            case 43: // Padding slot
+            case 44: // Padding slot
+                return false; // Cannot place items in padding slots
             default:
                 return true; // For non-special slots (main inventory), any item is generally allowed.
         }
@@ -106,6 +111,10 @@ public final class InventoryGUIHelper { // Made public and final
             case 38: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
             case 39: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
             case 40: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
+            case 41:
+            case 42:
+            case 43:
+            case 44: return createFillerItem(Material.BARRIER, " ", " "); // Padding slots
             default: return new ItemStack(Material.AIR); // Should not happen for these slots
         }
     }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -7,6 +7,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
@@ -17,7 +18,10 @@ import java.util.Collections;
 /**
  * A helper class for creating and validating items within the custom inventory GUIs.
  * This centralizes logic for filler items and slot-specific item validation.
+ *
+ * @since 5.2
  */
+@ApiStatus.AvailableSince("5.2")
 @Service
 public final class InventoryGUIHelper {
 
@@ -27,13 +31,18 @@ public final class InventoryGUIHelper {
     public InventoryGUIHelper(@NotNull MultiverseInventories inventories) {
         this.IS_FILLER_KEY = new NamespacedKey(inventories, "is_mvinv_filler");
     }
+
     /**
      * Creates a generic filler item for GUI slots.
+     *
      * @param material The material of the filler item.
      * @param name The display name of the item.
      * @param lore The lore text for the item.
      * @return The created ItemStack.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public ItemStack createFillerItem(Material material, String name, String lore) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
@@ -48,9 +57,13 @@ public final class InventoryGUIHelper {
 
     /**
      * Checks if a given ItemStack is a filler item created by this helper.
+     *
      * @param item The ItemStack to check.
      * @return True if the item is a filler, false otherwise.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public boolean isFillerItem(@NotNull ItemStack item) {
         if (!item.hasItemMeta()) {
             return false;
@@ -62,10 +75,14 @@ public final class InventoryGUIHelper {
     /**
      * Determines if an ItemStack is valid for a given special inventory slot in the custom GUI.
      * This method is used for both armor and off-hand slot validation.
+     *
      * @param item The ItemStack to check.
      * @param slot The raw slot number (36-40 for armor/off-hand).
      * @return True if the item is valid for the slot, false otherwise.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public boolean isValidItemForSlot(@NotNull ItemStack item, int slot) {
         if (item.getType() == Material.AIR) {
             return true; // Air is always valid (it means the slot is empty)
@@ -101,9 +118,13 @@ public final class InventoryGUIHelper {
 
     /**
      * Creates the appropriate filler item for a given special slot in the custom GUI.
+     *
      * @param slot The raw slot number (36-40).
      * @return The specific filler ItemStack for that slot.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public ItemStack createFillerItemForSlot(int slot) {
         switch (slot) {
             case 36: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -76,13 +76,13 @@ public final class InventoryGUIHelper { // Made public and final
         }
 
         switch (slot) {
-            case 39: // Helmet slot
+            case 36: // Helmet slot
                 return item.getType().name().endsWith("_HELMET");
-            case 38: // Chestplate slot
+            case 37: // Chestplate slot
                 return item.getType().name().endsWith("_CHESTPLATE");
-            case 37: // Leggings slot
+            case 38: // Leggings slot
                 return item.getType().name().endsWith("_LEGGINGS");
-            case 36: // Boots slot
+            case 39: // Boots slot
                 return item.getType().name().endsWith("_BOOTS");
             case 40: // Off-hand slot
                 // Off-hand is very permissive in vanilla. Allow any non-air item.
@@ -101,10 +101,10 @@ public final class InventoryGUIHelper { // Made public and final
      */
     public ItemStack createFillerItemForSlot(int slot) {
         switch (slot) {
-            case 39: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
-            case 38: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
-            case 37: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
-            case 36: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
+            case 36: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Helmet Slot", "Place Helmet Here");
+            case 37: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Chestplate Slot", "Place Chestplate Here");
+            case 38: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Leggings Slot", "Place Leggings Here");
+            case 39: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Boots Slot", "Place Boots Here");
             case 40: return createFillerItem(Material.GRAY_STAINED_GLASS_PANE, "Off-Hand Slot", "Place Off-Hand Item Here");
             default: return new ItemStack(Material.AIR); // Should not happen for these slots
         }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -142,6 +142,21 @@ public final class InventoryGUIHelper {
         };
     }
 
+
+    /**
+     * Helper method to get an item for a slot, returning a filler if the item is null or air.
+     * @param item The actual ItemStack from player data. Can be null.
+     * @param slot The slot number.
+     * @param isModifiable True if the inventory is modifiable.
+     * @return The actual item or a generated filler item.
+     */
+    private ItemStack getOrFillItem(ItemStack item, int slot, boolean isModifiable) {
+        if (item == null || item.getType() == Material.AIR) {
+            return createFillerItemForSlot(slot, isModifiable);
+        }
+        return item;
+    }
+
     /**
      * Populates the given custom inventory GUI with player inventory data and appropriate filler items.
      * @param inv The Inventory GUI to populate.
@@ -165,40 +180,23 @@ public final class InventoryGUIHelper {
         // Minecraft Internal: armor[3]=Helmet, armor[2]=Chestplate, armor[1]=Leggings, armor[0]=Boots
 
         // Slot 36: Helmet
-        if (playerInventoryData.armor == null || playerInventoryData.armor[3] == null) {
-            inv.setItem(36, createFillerItemForSlot(36, isModifiable));
-        } else {
-            inv.setItem(36, playerInventoryData.armor[3]);
-        }
+        inv.setItem(36, getOrFillItem((playerInventoryData.armor != null ? playerInventoryData.armor[3] : null), 36, isModifiable));
+
         // Slot 37: Chestplate
-        if (playerInventoryData.armor == null || playerInventoryData.armor[2] == null) {
-            inv.setItem(37, createFillerItemForSlot(37, isModifiable));
-        } else {
-            inv.setItem(37, playerInventoryData.armor[2]);
-        }
+        inv.setItem(37, getOrFillItem((playerInventoryData.armor != null ? playerInventoryData.armor[2] : null), 37, isModifiable));
+
         // Slot 38: Leggings
-        if (playerInventoryData.armor == null || playerInventoryData.armor[1] == null) {
-            inv.setItem(38, createFillerItemForSlot(38, isModifiable));
-        } else {
-            inv.setItem(38, playerInventoryData.armor[1]);
-        }
+        inv.setItem(38, getOrFillItem((playerInventoryData.armor != null ? playerInventoryData.armor[1] : null), 38, isModifiable));
+
         // Slot 39: Boots
-        if (playerInventoryData.armor == null || playerInventoryData.armor[0] == null) {
-            inv.setItem(39, createFillerItemForSlot(39, isModifiable));
-        } else {
-            inv.setItem(39, playerInventoryData.armor[0]);
-        }
+        inv.setItem(39, getOrFillItem((playerInventoryData.armor != null ? playerInventoryData.armor[0] : null), 39, isModifiable));
 
         // Off-hand slot (40) and add filler if empty
-        if (playerInventoryData.offHand == null || playerInventoryData.offHand.getType() == Material.AIR) {
-            inv.setItem(40, createFillerItemForSlot(40, isModifiable));
-        } else {
-            inv.setItem(40, playerInventoryData.offHand);
-        }
+        inv.setItem(40, getOrFillItem(playerInventoryData.offHand, 40, isModifiable));
 
         // Fill the remaining slots (41-44) with non-interactable filler items
         for (int i = 41; i <= 44; i++) {
-            inv.setItem(i, createFillerItemForSlot(i, isModifiable)); // Use createFillerItemForSlot for padding too
+            inv.setItem(i, createFillerItemForSlot(i, isModifiable));
         }
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryGUIHelper.java
@@ -10,6 +10,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jvnet.hk2.annotations.Service;
 import org.mvplugins.multiverse.external.jakarta.inject.Inject;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
@@ -181,22 +182,33 @@ public final class InventoryGUIHelper {
         return item;
     }
 
-    private ItemStack createHealthDisplayItem(double health, double maxHealth) {
+    private ItemStack createHealthDisplayItem(@Nullable Double health, @Nullable Double maxHealth) {
         List<String> lore = new ArrayList<>();
-        DecimalFormat df = new DecimalFormat("0.0");
-        lore.add(ChatColor.WHITE + "Current: " + ChatColor.RED + df.format(health) + ChatColor.WHITE + " / " + ChatColor.RED + df.format(maxHealth));
+        if (health == null) {
+            lore.add(ChatColor.RED + "N/A (No Data)");
+        } else {
+            DecimalFormat df = new DecimalFormat("0.0");
+            lore.add(ChatColor.WHITE + "Current: " + ChatColor.RED + df.format(health) + ChatColor.WHITE + " / " + ChatColor.RED + df.format(maxHealth));
+        }
         return createDisplayItem(Material.RED_DYE, "Health", lore);
     }
 
-    private ItemStack createLevelDisplayItem(int level, float exp) {
+    private ItemStack createLevelDisplayItem(@Nullable Integer level, @Nullable Float exp) {
         List<String> lore = new ArrayList<>();
-        lore.add(ChatColor.WHITE + "Level: " + ChatColor.GREEN + level);
-        lore.add(ChatColor.WHITE + "Progress: " + ChatColor.AQUA + String.format("%.1f%%", exp * 100));
+        if (level == null) {
+            lore.add(ChatColor.RED + "N/A (No Data)");
+        } else {
+            lore.add(ChatColor.WHITE + "Level: " + ChatColor.GREEN + level);
+            lore.add(ChatColor.WHITE + "Progress: " + ChatColor.AQUA + String.format("%.1f%%", exp * 100));
+        }
         return createDisplayItem(Material.EXPERIENCE_BOTTLE, "Experience", lore);
     }
 
-    private ItemStack createFoodDisplayItem(int foodLevel, float saturation) {
+    private ItemStack createFoodDisplayItem(@Nullable Integer foodLevel, @Nullable Float saturation) {
         List<String> lore = new ArrayList<>();
+        if (foodLevel == null) {
+            lore.add(ChatColor.RED + "N/A (No Data)");
+        }
         lore.add(ChatColor.WHITE + "Food: " + ChatColor.GOLD + foodLevel + ChatColor.WHITE + " / " + ChatColor.GOLD + "20");
         lore.add(ChatColor.WHITE + "Saturation: " + ChatColor.LIGHT_PURPLE + String.format("%.1f", saturation));
         return createDisplayItem(Material.COOKED_BEEF, "Food & Saturation", lore);

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryStatus.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/InventoryStatus.java
@@ -1,26 +1,40 @@
-package org.mvplugins.multiverse.inventories.profile;
+package org.mvplugins.multiverse.inventories.view;
 
 import org.bukkit.ChatColor;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the status of an inventory data load operation.
  * Provides a fixed set of states for clarity and type safety.
+ *
+ * @since 5.2
  */
+@ApiStatus.Experimental
+@ApiStatus.AvailableSince("5.2")
 public enum InventoryStatus {
     /**
      * Indicates that live inventory data from an online player was displayed.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     LIVE_INVENTORY(ChatColor.GREEN + "Displaying LIVE inventory"),
 
     /**
      * Indicates that stored inventory data from Multiverse-Inventories profiles was displayed.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     STORED_INVENTORY(ChatColor.GREEN + "Displaying STORED inventory"),
 
     /**
      * Indicates that no player data was found for the specified world/player.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     NO_DATA_FOUND(ChatColor.RED + "No player data found");
 
     private final String message;
@@ -35,7 +49,10 @@ public enum InventoryStatus {
      * @param playerName The name of the target player.
      * @param worldName  The name of the target world.
      * @return The formatted status message.
+     *
+     * @since 5.2
      */
+    @ApiStatus.AvailableSince("5.2")
     public @NotNull String getFormattedMessage(@NotNull String playerName, @NotNull String worldName) {
         if (this == NO_DATA_FOUND) {
             return this.message + " for " + playerName + " in world" + worldName + ". Try checking a different world or ensure the player has played in this world.";

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
@@ -3,6 +3,7 @@ package org.mvplugins.multiverse.inventories.view;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.mvplugins.multiverse.inventories.MultiverseInventories;
 import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
@@ -11,13 +12,26 @@ import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
  * A custom InventoryHolder that serves as a marker for modifiable inventories.
  * It stores the necessary context (player, world, profile type, plugin instance)
  * to save changes back to the player's profile when the inventory is closed.
+ *
+ * @since 5.2
  */
+@ApiStatus.AvailableSince("5.2")
 public final class ModifiableInventoryHolder implements InventoryHolder {
     private final OfflinePlayer targetPlayer;
     private final String worldName;
     private final ProfileType profileType;
     private final MultiverseInventories inventories;
 
+    /**
+     *
+     * @param targetPlayer
+     * @param worldName
+     * @param profileType
+     * @param inventories
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
     public ModifiableInventoryHolder(@NotNull OfflinePlayer targetPlayer,
                                      @NotNull String worldName,
                                      @NotNull ProfileType profileType,
@@ -28,22 +42,53 @@ public final class ModifiableInventoryHolder implements InventoryHolder {
         this.inventories = inventories;
     }
 
+    /**
+     *
+     * @return
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
     public @NotNull OfflinePlayer getTargetPlayer() {
         return targetPlayer;
     }
 
+    /**
+     *
+     * @return
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
     public @NotNull String getWorldName() {
         return worldName;
     }
 
+    /**
+     *
+     * @return
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
     public @NotNull ProfileType getProfileType() {
         return profileType;
     }
 
+    /**
+     *
+     * @return
+     *
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
     public @NotNull MultiverseInventories getInventories() {
         return inventories;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull Inventory getInventory() {
         // This method is required by the interface but is not directly used for the marker purpose.

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
@@ -1,0 +1,53 @@
+package org.mvplugins.multiverse.inventories.view;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
+
+/**
+ * A custom InventoryHolder that serves as a marker for modifiable inventories.
+ * It stores the necessary context (player, world, profile type, plugin instance)
+ * to save changes back to the player's profile when the inventory is closed.
+ */
+public final class ModifiableInventoryHolder implements InventoryHolder {
+    private final OfflinePlayer targetPlayer;
+    private final String worldName;
+    private final ProfileType profileType;
+    private final MultiverseInventories inventories;
+
+    public ModifiableInventoryHolder(@NotNull OfflinePlayer targetPlayer,
+                                     @NotNull String worldName,
+                                     @NotNull ProfileType profileType,
+                                     @NotNull MultiverseInventories inventories) {
+        this.targetPlayer = targetPlayer;
+        this.worldName = worldName;
+        this.profileType = profileType;
+        this.inventories = inventories;
+    }
+
+    public @NotNull OfflinePlayer getTargetPlayer() {
+        return targetPlayer;
+    }
+
+    public @NotNull String getWorldName() {
+        return worldName;
+    }
+
+    public @NotNull ProfileType getProfileType() {
+        return profileType;
+    }
+
+    public @NotNull MultiverseInventories getInventories() {
+        return inventories;
+    }
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        // This method is required by the interface but is not directly used for the marker purpose.
+        // Throwing UnsupportedOperationException clearly indicates it's not meant to be called.
+        throw new UnsupportedOperationException("ModifiableInventoryHolder does not provide an Inventory directly.");
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
@@ -20,7 +20,6 @@ public final class ModifiableInventoryHolder implements InventoryHolder {
     private final OfflinePlayer targetPlayer;
     private final String worldName;
     private final ProfileType profileType;
-    private final MultiverseInventories inventories;
 
     /**
      *
@@ -34,12 +33,10 @@ public final class ModifiableInventoryHolder implements InventoryHolder {
     @ApiStatus.AvailableSince("5.2")
     public ModifiableInventoryHolder(@NotNull OfflinePlayer targetPlayer,
                                      @NotNull String worldName,
-                                     @NotNull ProfileType profileType,
-                                     @NotNull MultiverseInventories inventories) {
+                                     @NotNull ProfileType profileType) {
         this.targetPlayer = targetPlayer;
         this.worldName = worldName;
         this.profileType = profileType;
-        this.inventories = inventories;
     }
 
     /**
@@ -73,17 +70,6 @@ public final class ModifiableInventoryHolder implements InventoryHolder {
     @ApiStatus.AvailableSince("5.2")
     public @NotNull ProfileType getProfileType() {
         return profileType;
-    }
-
-    /**
-     *
-     * @return
-     *
-     * @since 5.2
-     */
-    @ApiStatus.AvailableSince("5.2")
-    public @NotNull MultiverseInventories getInventories() {
-        return inventories;
     }
 
     /**

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ModifiableInventoryHolder.java
@@ -26,7 +26,6 @@ public final class ModifiableInventoryHolder implements InventoryHolder {
      * @param targetPlayer
      * @param worldName
      * @param profileType
-     * @param inventories
      *
      * @since 5.2
      */

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/PlayerInventoryData.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/PlayerInventoryData.java
@@ -1,0 +1,65 @@
+package org.mvplugins.multiverse.inventories.view;
+
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
+import org.mvplugins.multiverse.inventories.profile.key.ProfileType;
+
+/**
+ * Represents the loaded inventory data.
+ *
+ * @since 5.2
+ */
+@ApiStatus.Experimental
+@ApiStatus.AvailableSince("5.2")
+public final class PlayerInventoryData {
+    public final ItemStack[] contents;
+    public final ItemStack[] armor;
+    public final ItemStack offHand;
+    public final InventoryStatus status;
+    public final ProfileType profileTypeUsed;
+
+    // Non-inventory data
+    public final Double health;
+    public final Double maxHealth;
+    public final Integer level;
+    public final Float exp;
+    public final Integer foodLevel;
+    public final Float saturation;
+    public final String lastLocation;
+
+    /**
+     *
+     * @param contents        The player's main inventory contents (slots 0-35).
+     * @param armor           The player's armor contents (boots, leggings, chestplate, helmet).
+     * @param offHand         The player's off-hand item.
+     * @param status          The status of the inventory data load (e.g., LIVE, STORED, NO_DATA_FOUND).
+     * @param profileTypeUsed The profile type that was used to retrieve the data (e.g., SURVIVAL).
+     * @param health          The player's current health.
+     * @param maxHealth       The player's maximum health.
+     * @param level           The player's current experience level.
+     * @param exp             The player's current experience progress towards the next level (0.0-1.0).
+     * @param foodLevel       The player's current food level (0-20).
+     * @param saturation      The player's current saturation level.
+     * @param lastLocation    The player's last location.
+     * @since 5.2
+     */
+    @ApiStatus.AvailableSince("5.2")
+    public PlayerInventoryData(ItemStack[] contents, ItemStack[] armor, ItemStack offHand, InventoryStatus status,
+                               ProfileType profileTypeUsed, Double health, Double maxHealth, Integer level, Float exp, Integer foodLevel,
+                               Float saturation, String lastLocation) {
+        this.contents = contents;
+        this.armor = armor;
+        this.offHand = offHand;
+        this.status = status;
+        this.profileTypeUsed = profileTypeUsed;
+
+        // Non-inventory data
+        this.health = health;
+        this.maxHealth = maxHealth;
+        this.level = level;
+        this.exp = exp;
+        this.foodLevel = foodLevel;
+        this.saturation = saturation;
+        this.lastLocation = lastLocation;
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ReadOnlyInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ReadOnlyInventoryHolder.java
@@ -1,0 +1,19 @@
+package org.mvplugins.multiverse.inventories.view; // New package
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A custom InventoryHolder that serves as a marker for read-only inventories.
+ * Inventories created with this holder will have their interactions cancelled by the InventoryViewListener.
+ */
+public final class ReadOnlyInventoryHolder implements InventoryHolder {
+
+    @Override
+    public @NotNull Inventory getInventory() {
+        // This method is required by the interface but is not directly used for the marker purpose.
+        // Throwing UnsupportedOperationException clearly indicates it's not meant to be called.
+        throw new UnsupportedOperationException("ReadOnlyInventoryHolder does not provide an Inventory directly.");
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/inventories/view/ReadOnlyInventoryHolder.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/view/ReadOnlyInventoryHolder.java
@@ -2,14 +2,20 @@ package org.mvplugins.multiverse.inventories.view; // New package
 
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A custom InventoryHolder that serves as a marker for read-only inventories.
  * Inventories created with this holder will have their interactions cancelled by the InventoryViewListener.
+ *
+ * @since 5.2
  */
+@ApiStatus.AvailableSince("5.2")
 public final class ReadOnlyInventoryHolder implements InventoryHolder {
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull Inventory getInventory() {
         // This method is required by the interface but is not directly used for the marker purpose.

--- a/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
+++ b/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
@@ -15,7 +15,7 @@ class InjectionTest : TestWithMockBukkit() {
 
     @Test
     fun `InventoriesCommand are available as a service`() {
-        assertEquals(28, serviceLocator.getAllActiveServices(InventoriesCommand::class.java).size)
+        assertEquals(29, serviceLocator.getAllActiveServices(InventoriesCommand::class.java).size)
     }
 
     @Test

--- a/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
+++ b/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
@@ -15,7 +15,7 @@ class InjectionTest : TestWithMockBukkit() {
 
     @Test
     fun `InventoriesCommand are available as a service`() {
-        assertEquals(29, serviceLocator.getAllActiveServices(InventoriesCommand::class.java).size)
+        assertEquals(30, serviceLocator.getAllActiveServices(InventoriesCommand::class.java).size)
     }
 
     @Test

--- a/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
+++ b/src/test/java/org/mvplugins/multiverse/inventories/InjectionTest.kt
@@ -25,7 +25,7 @@ class InjectionTest : TestWithMockBukkit() {
 
     @Test
     fun `InventoriesListener is available as a service`() {
-        assertEquals(4, serviceLocator.getAllActiveServices(MVInvListener::class.java).size)
+        assertEquals(5, serviceLocator.getAllActiveServices(MVInvListener::class.java).size)
     }
 
     @Test


### PR DESCRIPTION
This PR introduces the `/mvinv view` and `/mvinv modify` commands, allowing admins to inspect or modify any player's (online or offline) inventory, armor, and off-hand contents in a specific Multiverse world, per suggestion #393. 

# Key Features:

* View Player Inventories: See a player's items across worlds.

* Offline Support: Works for both online and offline players.

* Read-Only GUI: Prevents accidental modification of inventories with `/mvinv view`

* Write-Access GUI: Allows admins to modify inventories with `/mvinv modify`

* Autocompletion: Provides suggestions for player names and worlds.

# Usage:
`/mvinv view <player> <world>`
`/mvinv modify <player> <world>`

# Permission:
`multiverse.inventories.view`
`multiverse.inventories.view.modify`

# Known Issue:
Item Quantity Display Bug: The inventory GUI may sometimes display incorrect quantities for stacked items, particularly armor and weapons, showing '1' instead of the actual stack size. This is a visual bug and does not affect the actual item data.