### PR TITLE
Revert refactor bulkedit commands to remove "bulkedit" prefix

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/BulkEditCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/BulkEditCommand.java
@@ -13,7 +13,6 @@ import org.mvplugins.multiverse.inventories.profile.bulkedit.BulkEditResult;
 
 @Contract
 @ApiStatus.Internal
-@Subcommand("bulkedit")
 public abstract class BulkEditCommand extends InventoriesCommand {
 
     protected final BulkEditCreator bulkEditCreator;

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/globalprofile/ClearCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/globalprofile/ClearCommand.java
@@ -42,7 +42,7 @@ final class ClearCommand extends BulkEditCommand {
         this.flags = flags;
     }
 
-    @Subcommand("globalprofile clear")
+    @Subcommand("bulkedit globalprofile clear")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("@mvinvplayernames @flags:groupName=" + Flags.NAME)
     @Syntax("<players> [--clear-all-player-profiles]")

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/globalprofile/ModifyCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/globalprofile/ModifyCommand.java
@@ -31,7 +31,7 @@ final class ModifyCommand extends InventoriesCommand {
         this.profileDataSource = profileDataSource;
     }
 
-    @Subcommand("globalprofile modify")
+    @Subcommand("bulkedit globalprofile modify")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("load-on-login|last-world @empty @mvinvplayernames")
     @Syntax("<property> <value> <players>")

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/ClearCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/ClearCommand.java
@@ -37,7 +37,7 @@ final class ClearCommand extends BulkEditCommand {
         this.flags = flags;
     }
 
-    @Subcommand("playerprofile clear")
+    @Subcommand("bulkedit playerprofile clear")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("@mvinvplayernames @mvinvcontainerkeys @mvinvprofiletypes:multiple @flags:groupName=" + IncludeGroupsWorldsFlag.NAME)
     @Syntax("<players> <groups/worlds> [profile-type] [--include-groups-worlds]")

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/ClonePlayerCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/ClonePlayerCommand.java
@@ -36,7 +36,7 @@ public class ClonePlayerCommand extends BulkEditCommand {
         this.flags = flags;
     }
 
-    @Subcommand("playerprofile clone-player")
+    @Subcommand("bulkedit playerprofile clone-player")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("@mvinvplayername @mvinvplayername @mvinvcontainerkeys @mvinvprofiletypes:multiple " +
             "@flags:groupName=" + IncludeGroupsWorldsFlag.NAME)

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/CloneWorldGroupCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/CloneWorldGroupCommand.java
@@ -39,7 +39,7 @@ public class CloneWorldGroupCommand extends BulkEditCommand {
         this.flags = flags;
     }
 
-    @Subcommand("playerprofile clone-world-group")
+    @Subcommand("bulkedit playerprofile clone-world-group")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("@mvinvplayernames @mvinvcontainerkey @mvinvcontainerkeys @mvinvprofiletypes:multiple " +
             "@flags:groupName=" + IncludeGroupsWorldsFlag.NAME)

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/DeleteCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/DeleteCommand.java
@@ -38,7 +38,7 @@ final class DeleteCommand extends BulkEditCommand {
         this.flags = flags;
     }
 
-    @Subcommand("playerprofile delete")
+    @Subcommand("bulkedit playerprofile delete")
     @CommandPermission("multiverse.inventories.bulkedit")
     @CommandCompletion("@shares @mvinvplayernames @mvinvcontainerkeys @mvinvprofiletypes:multiple @flags:groupName=" + IncludeGroupsWorldsFlag.NAME)
     @Syntax("<sharable> <players> <groups/worlds> [profile-type] [--include-groups-worlds]")

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/MigrateInventorySerializationCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/MigrateInventorySerializationCommand.java
@@ -40,7 +40,7 @@ final class MigrateInventorySerializationCommand extends InventoriesCommand {
         this.inventoriesConfig = inventoriesConfig;
     }
 
-    @Subcommand("migrate inventory-serialization nbt")
+    @Subcommand("bulkedit migrate inventory-serialization nbt")
     @CommandPermission("multiverse.inventories.bulkedit")
     void onNbtCommand(MVCommandIssuer issuer) {
         commandQueueManager.addToQueue(CommandQueuePayload.issuer(issuer)
@@ -48,7 +48,7 @@ final class MigrateInventorySerializationCommand extends InventoriesCommand {
                 .action(() -> doMigration(issuer, true)));
     }
 
-    @Subcommand("migrate inventory-serialization bukkit")
+    @Subcommand("bulkedit migrate inventory-serialization bukkit")
     @CommandPermission("multiverse.inventories.bulkedit")
     void onBukkitCommand(MVCommandIssuer issuer) {
         commandQueueManager.addToQueue(CommandQueuePayload.issuer(issuer)

--- a/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/MigratePlayerNameCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/inventories/commands/bulkedit/playerprofile/MigratePlayerNameCommand.java
@@ -25,7 +25,7 @@ final class MigratePlayerNameCommand extends InventoriesCommand {
         this.profileDataSource = profileDataSource;
     }
 
-    @Subcommand("migrate player-name")
+    @Subcommand("bulkedit migrate player-name")
     @CommandPermission("multiverse.inventories.bulkedit")
     @Syntax("<current-name> <new-name>")
     @Description("Only use this if automatic migration failed for some reason.")


### PR DESCRIPTION
It was causing the `migrate` commands to not have the `bulkedit` prefix and instead overrided the 3rd party plugin migrate command. I think its probably a bug with ACF.

<!-- artifact-comment-section 656 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-inventories-pr656](https://nightly.link/Multiverse/Multiverse-Inventories/actions/runs/20650236360/multiverse-inventories-pr656.zip)

<!-- artifact-comment-section 656 end (DO NOT EDIT ABOVE) -->